### PR TITLE
Expanded and corrected notify_build_farm.rst.

### DIFF
--- a/doc/tutorials/notify_build_farm.rst
+++ b/doc/tutorials/notify_build_farm.rst
@@ -1,10 +1,21 @@
 Notifying the buildfarm
 =======================
 
-Test first by checking out to a tag and then running this command::
+First you should test the build.
 
-    $ git checkout debian/groovy/ros-groovy-<package>_<version>-<debinc>_<distro>
+Start by checking out from the tag of the build you are releasing::
+
+    $ git checkout debian/ros-groovy-<package>_<version>-<debinc>_<distro>
+
+Where:
+
+ * <package> is your package name, like "rviz" or "interactive_markers".
+ * <version> is the version you are releasing, like 1.9.2.
+ * <debinc> is the debian build number, often 0.  It only increments to re-run a build.  If upstream source code has changed, the version number should increment instead and <debinc> should go back to 0.
+ * <distro> is the OS distribution, like precise or quantal.
+
+Then run the build with this command::
+
     $ git-buildpackage -uc -us --git-ignore-branch
 
-Once you have pushed your changes to the release repository, you still need to update the file that the build farm uses to generate jobs which is currently located at `https://github.com/ros/rosdistro/blob/master/releases/groovy.yaml <https://github.com/ros/rosdistro/blob/master/releases/groovy.yaml>`_
-
+If this succeeds, and you have pushed your changes and tags as previously instructed, you still need to update the file that the build farm uses to generate jobs which is currently located at `https://github.com/ros/rosdistro/blob/master/releases/groovy.yaml <https://github.com/ros/rosdistro/blob/master/releases/groovy.yaml>`_


### PR DESCRIPTION
original verison of 'git checkout' command had 'debian/groovy/ros-groovy...'
but actual tags generated by git-bloom were like 'debian/ros-groovy...'.
Also expanded and clarified instructions.
