### PR TITLE
None/version tag created with bloom 3.1

### DIFF
--- a/bloom/commands/git/import_upstream.py
+++ b/bloom/commands/git/import_upstream.py
@@ -257,7 +257,7 @@ def import_upstream(tarball_path, patches_path, version, name, replace):
         warning("Removing tag: '{0}'".format(upstream_tag))
         delete_tag(upstream_tag)
         delete_remote_tag(upstream_tag)
-    name_tag = '{0}/{1}'.format(name, version)
+    name_tag = '{0}/{1}'.format(name or 'upstream', version)
     if name_tag != upstream_tag and tag_exists(name_tag):
         if not replace:
             error("Tag '{0}' already exists, use --replace to override it."


### PR DESCRIPTION
I was releasing OpenCV, nothing crashes but I get that:

```
vrabaud@awesome:~/workspace/packages_debs/opencv2-releaseNew$ git-bloom-release groovy
Processing release track settings for 'groovy'
What version are you releasing (version should normally be MAJOR.MINOR.PATCH)? 2.4.3
What upstream tag should bloom import from? 5b7a4cd955d14df0781a2b984934ba2cfc3eebff

Executing release track 'groovy'
==> bloom-export-upstream https://github.com/Itseez/opencv.git git --tag 5b7a4cd955d14df0781a2b984934ba2cfc3eebff --display-uri https://github.com/Itseez/opencv.git --name upstream --output-dir /tmp/tmpiVIdwD
Checking out repository at 'https://github.com/Itseez/opencv.git' to reference '5b7a4cd955d14df0781a2b984934ba2cfc3eebff'.
Exporting to archive: '/tmp/tmpiVIdwD/upstream-5b7a4cd955d14df0781a2b984934ba2cfc3eebff.tar.gz'
md5: 4693a909208152fa933ba8dbcb5648ba

==> git-bloom-import-upstream /tmp/tmpiVIdwD/upstream-5b7a4cd955d14df0781a2b984934ba2cfc3eebff.tar.gz groovy --release-version 2.4.3 --replace
Creating upstream branch.
Importing archive into upstream branch...
Overlaying files from patched folder 'groovy' on the 'bloom' branch into the 'upstream' branch...
  Templating 'package.xml' into upstream branch...
Creating tag: 'upstream/2.4.3'
Creating tag: 'None/2.4.3'
I'm happy.  You should be too.
```

Note the: "Creating tag: 'None/2.4.3'" (which does get created).

My config:

```
Repository Name:
  upstream
    Default value, leave this as upstream if you are unsure
  <name>
    Name of the repository (used in the archive name)
  ['upstream']: Upstream Repository URI:
  <uri>
    Any valid URI. This variable can be templated, for example an svn url
    can be templated as such: "https://svn.foo.com/foo/tags/foo-:{version}"
    where the :{version} token will be replaced with the version for this release.
  ['https://github.com/Itseez/opencv.git']: Upstream VCS Type:
  svn
    Upstream URI is a svn repository
  git
    Upstream URI is a git repository
  hg
    Upstream URI is a hg repository
  tar
    Upstream URI is a tarball
  ['git']: Version:
  :{ask}
    This means that the user will be prompted for the version each release.
    This also means that the upstream devel will be ignored.
  :{auto}
    This means the version will be guessed from the devel branch.
    This means that the devel branch must be set, the devel branch must exist,
    and there must be a valid package.xml in the upstream devel branch.
  <version>
    This will be the version used.
    It must be updated for each new upstream version.
  [':{ask}']: Release Tag:
  :{none}
    For svn and tar only you can set the release tag to :{none}, so that
    it is ignored.  For svn this means no revision number is used.
  :{ask}
    This means the user will be prompted for the release tag on each release.
  :{version}
    This means that the release tag will match the :{version} tag.
    This can be further templated, for example: "foo-:{version}" or "v:{version}"

    This can describe any vcs reference. For git that means {tag, branch, hash},
    for hg that means {tag, branch, hash}, for svn that means a revision number.
    For tar this value doubles as the sub directory (if the repository is
    in foo/ of the tar ball, putting foo here will cause the contents of
    foo/ to be imported to upstream instead of foo itself).
  [':{ask}']: 
Upstream Devel Branch:
  <vcs reference>
    Branch in upstream repository on which to search for the version.
    This is used only when version is set to ':{auto}'.
  ['2.4']: 
ROS Distro:
  <ROS distro>
    This can be any valid ROS distro, e.g. groovy, hydro
  ['groovy']: 
Patches Directory:
  <path in bloom branch>
    This can be any valid relative path in the bloom branch. The contents
    of this folder will be overlaid onto the upstream branch after each
    import-upstream.  Additionally, any package.xml files found in the
    overlay will have the :{version} string replaced with the current
    version being released.
  ['groovy']: 
```
