### PR TITLE
Crash when running git-bloom-generate from not-a-branch

### DIFF
--- a/bloom/commands/git/branch.py
+++ b/bloom/commands/git/branch.py
@@ -49,6 +49,8 @@ def execute_branch(src, dst, interactive, directory=None):
     :raises: subprocess.CalledProcessError if any git calls fail
     """
     # Determine if the srouce branch exists
+    if src is None:
+        error("No source specified and/or not a branch currently", exit=True)
     if branch_exists(src, local_only=False, directory=directory):
         if not branch_exists(src, local_only=True, directory=directory):
             debug("Tracking source branch: {0}".format(src))
@@ -57,7 +59,7 @@ def execute_branch(src, dst, interactive, directory=None):
         pass
     else:
         error("Specified source branch does not exist: {0}".format(src),
-            exit=True)
+              exit=True)
 
     # Determine if the destination branch needs to be created
     create_dst_branch = False
@@ -123,7 +125,7 @@ def execute_branch(src, dst, interactive, directory=None):
             config = get_patch_config(dst_patches, directory=directory)
             if config['parent'] != src:
                 warning("Updated parent to '{0}' from '{1}'"
-                    .format(src, config['parent']))
+                        .format(src, config['parent']))
                 config['parent'] = src
                 config['base'] = get_commit_hash(dst, directory=directory)
             set_patch_config(dst_patches, config, directory=directory)

--- a/bloom/commands/git/patch/export_cmd.py
+++ b/bloom/commands/git/patch/export_cmd.py
@@ -24,6 +24,8 @@ def export_patches(directory=None):
     ensure_clean_working_env(git_status=True, directory=directory)
     # Get current branch
     current_branch = get_current_branch(directory)
+    if current_branch is None:
+        error("Could not determine current branch.", exit=True)
     # Construct the patches branch name
     patches_branch = 'patches/' + current_branch
     # Ensure the patches branch exists

--- a/bloom/commands/git/patch/import_cmd.py
+++ b/bloom/commands/git/patch/import_cmd.py
@@ -30,6 +30,8 @@ from bloom.commands.git.patch.common import list_patches
 def import_patches(directory=None):
     # Get current branch
     current_branch = get_current_branch(directory)
+    if current_branch is None:
+        error("Could not determine current branch.", exit=True)
     # Construct the patches branch name
     patches_branch = 'patches/' + current_branch
     # Ensure the patches branch exists and is tracked

--- a/bloom/commands/git/patch/remove_cmd.py
+++ b/bloom/commands/git/patch/remove_cmd.py
@@ -22,6 +22,8 @@ from bloom.util import handle_global_arguments
 def remove_patches(directory=None):
     # Get the current branch
     current_branch = get_current_branch(directory)
+    if current_branch is None:
+        error("Could not determine current branch.", exit=True)
     # Ensure the current branch is valid
     if current_branch is None:
         error("Could not determine current branch, are you in a git repo?",

--- a/bloom/commands/git/patch/trim_cmd.py
+++ b/bloom/commands/git/patch/trim_cmd.py
@@ -61,7 +61,10 @@ def _undo(config, directory):
         debug("Branch has not been trimmed previously, undo not required.")
         return None
     # Reset with git-revert
-    cmt = get_commit_hash(get_current_branch(directory), directory)
+    current_branch = get_current_branch(directory)
+    if current_branch is None:
+        error("Could not determine current branch.", exit=True)
+    cmt = get_commit_hash(current_branch, directory)
     cmd = 'git revert --no-edit -Xtheirs ' + config['trimbase'] + '..' + cmt
     execute_command(cmd, cwd=directory)
     # Unset the trimbase
@@ -80,7 +83,10 @@ def _trim(config, force, directory):
         else:
             warning("If you would like to continue anyways use '--force'")
             return None
-    config['trimbase'] = get_commit_hash(get_current_branch(directory))
+    current_branch = get_current_branch(directory)
+    if current_branch is None:
+        error("Could not determine current branch.", exit=True)
+    config['trimbase'] = get_commit_hash(current_branch)
     tmp_dir = tempfile.mkdtemp()
     try:
         # Buckup trim sub directory
@@ -129,7 +135,10 @@ def _trim(config, force, directory):
               config['trim'] + ' sub directory"'
         execute_command(cmd, cwd=directory)
         # Update the patch base to be this commit
-        config['base'] = get_commit_hash(get_current_branch(directory))
+        current_branch = get_current_branch(directory)
+        if current_branch is None:
+            error("Could not determine current branch.", exit=True)
+        config['base'] = get_commit_hash(current_branch)
     finally:
         if os.path.exists(tmp_dir):
             shutil.rmtree(tmp_dir)

--- a/bloom/commands/git/release.py
+++ b/bloom/commands/git/release.py
@@ -104,9 +104,13 @@ def clean_up_repositories():
 def get_upstream_meta(upstream_dir, ros_distro):
     meta = None
     with change_directory(upstream_dir):
-        name, version, stackages = get_package_data(get_current_branch(),
-                                                    quiet=False,
-                                                    fuerte=(ros_distro == 'fuerte'))
+        current_branch = get_current_branch()
+        if current_branch is None:
+            error("Could not determine current branch.", exit=True)
+        name, version, stackages = get_package_data(
+            current_branch,
+            quiet=False,
+            fuerte=(ros_distro == 'fuerte'))
     meta = {
         'name': name,
         'version': version,

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -231,7 +231,10 @@ class DebianGenerator(BloomGenerator):
         # Store it
         self.store_original_config(config, patches_branch)
         # Modify the base so import/export patch works
-        config['base'] = get_commit_hash(get_current_branch())
+        current_branch = get_current_branch()
+        if current_branch is None:
+            error("Could not determine current branch.", exit=True)
+        config['base'] = get_commit_hash(current_branch)
         # Set it
         set_patch_config(patches_branch, config)
 

--- a/bloom/generators/release.py
+++ b/bloom/generators/release.py
@@ -5,6 +5,7 @@ from bloom.generators import BloomGenerator
 from bloom.git import inbranch
 from bloom.git import get_current_branch
 
+from bloom.logging import error
 from bloom.logging import info
 from bloom.logging import warning
 
@@ -39,7 +40,13 @@ each package in the upstream repository, so the source branch should be set to
     def handle_arguments(self, args):
         self.interactive = args.interactive
         self.prefix = args.prefix
-        self.src = args.src if args.src is not None else get_current_branch()
+        if args.src is None:
+            current_branch = get_current_branch()
+            if current_branch is None:
+                error("Could not determine current branch.", exit=True)
+            self.src = current_branch
+        else:
+            self.src = args.src
         self.name = args.name
         self.release_inc = args.release_increment
 
@@ -47,11 +54,8 @@ each package in the upstream repository, so the source branch should be set to
         self.branch_list = self.detect_branches()
         if type(self.branch_list) not in [list, tuple]:
             self.exit(self.branch_list if self.branch_list is not None else 1)
-        info(
-            "Releasing package" + \
-            ('' if len(self.branch_list) == 1 else 's') + ": " + \
-            str(self.branch_list)
-        )
+        info("Releasing package" +
+             ('' if len(self.branch_list) == 1 else 's') + ": " + str(self.branch_list))
 
     def get_branching_arguments(self):
         p, s, i = self.prefix, self.src, self.interactive


### PR DESCRIPTION
Here is the trace:

```
Traceback (most recent call last):
  File "/usr/local/bin/git-bloom-generate", line 9, in <module>
    load_entry_point('bloom==0.2.16', 'console_scripts', 'git-bloom-generate')()
  File "/wg/stor5/pmathieu/devel/bloom/bloom/commands/git/generate.py", line 238, in main
    git_clone.commit()
  File "/wg/stor5/pmathieu/devel/bloom/bloom/git.py", line 94, in commit
    with inbranch(get_commit_hash(get_current_branch())):
  File "/wg/stor5/pmathieu/devel/bloom/bloom/git.py", line 340, in get_commit_hash
    cmd = 'git show-branch --sha1-name ' + reference
TypeError: cannot concatenate 'str' and 'NoneType' objects
```
