### PR TITLE
import-upstream should template stack.xml on overlay

### DIFF
--- a/bloom/commands/git/import_upstream.py
+++ b/bloom/commands/git/import_upstream.py
@@ -178,7 +178,7 @@ def handle_tree(tree, directory, root_path, version):
                         .format(rel_path))
                 execute_command('git rm {0}'.format(rel_path), shell=True)
             # If package.xml tempalte in version, else grab data
-            if path == 'package.xml':
+            if path in ['package.xml', 'stack.xml']:
                 info("  Templating '{0}' into upstream branch..."
                      .format(rel_path))
                 file_data = show('bloom', os.path.join(root_path, rel_path))


### PR DESCRIPTION
Currently on package.xml's are templated.
