### PR TITLE
bug in error message (no template)

### DIFF
--- a/bloom/commands/git/release.py
+++ b/bloom/commands/git/release.py
@@ -188,6 +188,7 @@ def process_track_settings(track_dict, release_inc_override):
             error("You must specify a version to continue.", exit=True)
         version = ret
     settings['version'] = version
+    vcs_uri = vcs_uri.replace(':{version}', version)
     settings['vcs_local_uri'] = repo.get_path() if repo else vcs_uri
     # Now that we have a version, template the vcs_uri if needed
     if ':{version}' in vcs_uri:


### PR DESCRIPTION
When using a template item in the URL (for SVN), the error message is not formatted appropriately:

```
==> bloom-export-upstream http://svn.pointclouds.org/pcl/tags/pcl-:{version}/ svn --tag :{none} --display-uri http://svn.pointclouds.org/pcl/tags/pcl-1.6.0/ --name upstream --output-dir /tmp/tmps0kl2Y
Checking out repository at 'http://svn.pointclouds.org/pcl/tags/pcl-1.6.0/'.
svn: URL 'http://svn.pointclouds.org/pcl/tags/pcl-:%7Bversion%7D' doesn't exist
Failed to clone repository at 'http://svn.pointclouds.org/pcl/tags/pcl-:{version}/'.
<== Error running command 'bloom-export-upstream http://svn.pointclouds.org/pcl/tags/pcl-:{version}/ svn --tag :{none} --display-uri http://svn.pointclouds.org/pcl/tags/pcl-1.6.0/ --name upstream --output-dir /tmp/tmps0kl2Y'
```
