### PR TITLE
get_upstream_meta() fails for hg

### DIFF
--- a/bloom/commands/git/release.py
+++ b/bloom/commands/git/release.py
@@ -53,6 +53,7 @@ from bloom.config import write_tracks_dict_raw
 
 from bloom.git import ensure_clean_working_env
 from bloom.git import get_current_branch
+from bloom.git import get_root
 
 from bloom.logging import error
 from bloom.logging import fmt
@@ -104,9 +105,10 @@ def clean_up_repositories():
 def get_upstream_meta(upstream_dir, ros_distro):
     meta = None
     with change_directory(upstream_dir):
-        current_branch = get_current_branch()
-        if current_branch is None:
-            error("Could not determine current branch.", exit=True)
+        if get_root() is not None:  # If in a git repo
+            current_branch = get_current_branch()
+        else:
+            current_branch = None
         name, version, stackages = get_package_data(
             current_branch,
             quiet=False,

--- a/bloom/util.py
+++ b/bloom/util.py
@@ -140,7 +140,7 @@ class temporary_directory(object):
             os.chdir(self.original_cwd)
 
 
-def get_package_data(branch_name, directory=None, quiet=True, fuerte=False):
+def get_package_data(branch_name=None, directory=None, quiet=True, fuerte=False):
     """
     Gets package data about the package(s) in the current branch.
 
@@ -151,7 +151,10 @@ def get_package_data(branch_name, directory=None, quiet=True, fuerte=False):
     stack_path = os.path.join(repo_dir, 'stack.xml')
     if os.path.exists(stack_path) and not fuerte:
             warning("stack.xml is present but going to be ignored because this is not a release for Fuerte.")
-    log("Looking for packages in '{0}' branch... ".format(branch_name), end='')
+    if branch_name:
+        log("Looking for packages in '{0}' branch... ".format(branch_name), end='')
+    else:
+        log("Looking for packages in '{0}'... ".format(directory or os.getcwd()), end='')
     ## Check for package.xml(s)
     if not fuerte:
         packages = find_packages(repo_dir)


### PR DESCRIPTION
Then, in release.py the call to get_upstream_meta() fails  because it
uses a get_current_branch() call which calls git. The checked out code
is hg, so git fails.
