### PR TITLE
checking if a path exists

### DIFF
--- a/bloom/commands/git/release.py
+++ b/bloom/commands/git/release.py
@@ -83,15 +83,16 @@ def get_upstream_repo(uri, vcs_type):
     global upstream_repos
     if uri not in upstream_repos:
         temp_dir = tempfile.mkdtemp()
-        upstream_repos[uri] = get_vcs_client(vcs_type, temp_dir)
-    return upstream_repos[uri]
+        upstream_dir = os.path.join(temp_dir, 'upstream')
+        upstream_repos[uri] = (temp_dir, get_vcs_client(vcs_type, upstream_dir))
+    return upstream_repos[uri][1]
 
 
 @atexit.register
 def clean_up_repositories():
     global upstream_repos
     for uri in upstream_repos:
-        path = upstream_repos[uri].get_path()
+        path = upstream_repos[uri][0]
         if os.path.exists(path):
             shutil.rmtree(path)
 

--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -100,7 +100,8 @@ def get_repo_uri(repository, distro, distro_file_url=ROS_DISTRO_FILE):
     distro_file_url = distro_file_url.format(distro)
     distro_file = yaml.load(fetch_distro_file(distro_file_url))
     if repository not in distro_file['repositories']:
-        error("Specified repository '{0}' is not in the distro file located at '{1}'".format(repository, distro_file_url),
+        error("Specified repository '{0}' is not in the distro file located at '{1}'"
+              .format(repository, distro_file_url),
               exit=True)
     return distro_file['repositories'][repository]['url']
 
@@ -120,8 +121,9 @@ def get_release_repo(repository, distro):
 def check_for_bloom_conf(repository):
     bloom_ls = ls_tree('bloom')
     if bloom_ls is None:
-        error("Release repository '{0}' not initialized, please initialize the bloom repository before releasing from it."
-              .format(repository), exit=True)
+        error("Release repository '{0}' not initialized,".format(repository) +
+              " please initialize the bloom repository before releasing from it.",
+              exit=True)
     bloom_files = [f for f, t in bloom_ls.iteritems() if t == 'file']
     return 'bloom.conf' in bloom_files
 


### PR DESCRIPTION
In vcstools, hg.py, checkout(), I had to disable this check:

if self.path_exists():
            sys.stderr.write("Error: cannot checkout into existing directory\n")
            return False

Obviously the solution is not to disable it, but it seems to me
path_exists() should return true for a temp path that was just
created.
I think this should also allow for empty folders;
