### PR TITLE
git-bloom-patch export does not check if directory exists after branch checkout

### DIFF
--- a/bloom/commands/export_upstream.py
+++ b/bloom/commands/export_upstream.py
@@ -58,7 +58,7 @@ try:
     from vcstools.vcs_abstraction import get_vcs_client
 except ImportError:
     error("vcstools was not detected, please install it.", file=sys.stderr,
-        exit=True)
+          exit=True)
 
 
 def get_argument_parser():
@@ -110,23 +110,23 @@ def export_upstream(uri, tag, vcs_type, output_dir, show_uri, name):
             upstream_repo = get_vcs_client(vcs_type, repo_path)
             if not upstream_repo.checkout(uri, tag or ''):
                 error("Failed to clone repository at '{0}'".format(uri) +
-                    (" to reference '{0}'.".format(tag) if tag else '.'),
-                    exit=True)
+                      (" to reference '{0}'.".format(tag) if tag else '.'),
+                      exit=True)
         tarball_prefix = '{0}-{1}'.format(name, tag) if tag else name
         tarball_path = os.path.join(output_dir, tarball_prefix)
         full_tarball_path = tarball_path + '.tar.gz'
         info("Exporting to archive: '{0}'".format(full_tarball_path))
         if not upstream_repo.export_repository(tag or '', tarball_path):
             error("Failed to create archive of upstream repository at '{0}'"
-                .format(show_uri))
+                  .format(show_uri))
             if tag:
                 with change_directory(upstream_repo.get_path()):
                     if not tag_exists(tag):
                         warning("'{0}' is not a tag in the upstream repository..."
-                            .format(tag))
+                                .format(tag))
                     if not branch_exists(tag):
                         warning("'{0}' is not a branch in the upstream repository..."
-                            .format(tag))
+                                .format(tag))
         if not os.path.exists(full_tarball_path):
             error("Tarball was not created.", exit=True)
         info("md5: {0}".format(calculate_file_md5(full_tarball_path)))
@@ -139,4 +139,4 @@ def main(sysargs=None):
     handle_global_arguments(args)
 
     export_upstream(args.uri, args.tag, args.type, args.output_dir,
-        args.display_uri, args.name)
+                    args.display_uri, args.name)

--- a/bloom/commands/git/branch.py
+++ b/bloom/commands/git/branch.py
@@ -6,6 +6,7 @@ from bloom.git import branch_exists
 from bloom.git import checkout
 from bloom.git import create_branch
 from bloom.git import ensure_clean_working_env
+from bloom.git import ensure_git_root
 from bloom.git import get_commit_hash
 from bloom.git import get_current_branch
 from bloom.git import ls_tree
@@ -163,8 +164,13 @@ def main(sysargs=None):
     args = parser.parse_args(sysargs)
     handle_global_arguments(args)
 
-    # Check environment
-    ensure_clean_working_env()
+    # Check that the current directory is a serviceable git/bloom repo
+    try:
+        ensure_clean_working_env()
+        ensure_git_root()
+    except SystemExit:
+        parser.print_usage()
+        raise
 
     # If the src argument isn't set, use the current branch
     if args.src is None:

--- a/bloom/commands/git/generate.py
+++ b/bloom/commands/git/generate.py
@@ -44,6 +44,8 @@ from bloom.generators import GeneratorError
 from bloom.generators import list_generators
 from bloom.generators import load_generator
 
+from bloom.git import ensure_clean_working_env
+from bloom.git import ensure_git_root
 from bloom.git import GitClone
 
 from bloom.logging import debug
@@ -228,6 +230,14 @@ def main(sysargs=None):
     handle_global_arguments(args)
 
     generator = generators[args.generator]
+
+    # Check that the current directory is a serviceable git/bloom repo
+    try:
+        ensure_clean_working_env()
+        ensure_git_root()
+    except SystemExit:
+        parser.print_usage()
+        raise
 
     # Run the generator that was selected in a clone
     # The clone protects the release repo state from mid change errors

--- a/bloom/commands/git/import_upstream.py
+++ b/bloom/commands/git/import_upstream.py
@@ -42,9 +42,9 @@ from pkg_resources import parse_version
 from bloom.git import branch_exists
 from bloom.git import create_branch
 from bloom.git import create_tag
-from bloom.git import delete_remote_tag
 from bloom.git import delete_tag
 from bloom.git import ensure_clean_working_env
+from bloom.git import ensure_git_root
 from bloom.git import get_last_tag_by_version
 from bloom.git import GitClone
 from bloom.git import has_changes
@@ -327,6 +327,7 @@ def main(sysargs=None):
     # Check that the current directory is a serviceable git/bloom repo
     try:
         ensure_clean_working_env()
+        ensure_git_root()
     except SystemExit:
         parser.print_usage()
         raise

--- a/bloom/commands/git/patch/export_cmd.py
+++ b/bloom/commands/git/patch/export_cmd.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from bloom.git import branch_exists
 from bloom.git import checkout
 from bloom.git import ensure_clean_working_env
+from bloom.git import ensure_git_root
 from bloom.git import get_current_branch
 from bloom.git import has_changes
 
@@ -82,4 +83,7 @@ branch, which is named 'patches/<current branch name>', using git format-patch.
 
 def main(args):
     handle_global_arguments(args)
+
+    ensure_git_root()
+
     return export_patches()

--- a/bloom/commands/git/patch/patch_main.py
+++ b/bloom/commands/git/patch/patch_main.py
@@ -5,6 +5,7 @@ import sys
 import traceback
 from subprocess import CalledProcessError
 
+from bloom.git import ensure_git_root
 from bloom.git import get_root
 
 from bloom.logging import error
@@ -45,6 +46,7 @@ def main(sysargs=None):
     if get_root() is None:
         parser.print_help()
         error("This command must be run in a valid git repository.", exit=True)
+    ensure_git_root()
     try:
         retcode = args.func(args) or 0
     except CalledProcessError as err:

--- a/bloom/commands/git/release.py
+++ b/bloom/commands/git/release.py
@@ -52,6 +52,7 @@ from bloom.config import verify_track
 from bloom.config import write_tracks_dict_raw
 
 from bloom.git import ensure_clean_working_env
+from bloom.git import ensure_git_root
 from bloom.git import get_current_branch
 from bloom.git import get_root
 
@@ -288,6 +289,7 @@ def get_argument_parser(tracks):
 def main(sysargs=None):
     # Check that the current directory is a serviceable git/bloom repo
     ensure_clean_working_env()
+    ensure_git_root()
 
     # Get tracks
     tracks_dict = get_tracks_dict_raw()

--- a/bloom/git.py
+++ b/bloom/git.py
@@ -223,7 +223,7 @@ def ensure_clean_working_env(force=False, git_status=True, directory=None):
         error(code, exit=True)
     # Is it a git repo
     if get_root(directory) is None:
-        error("Not is a valid git repository", exit=True)
+        error("Not in a valid git repository", exit=True)
     # Are we on a branch?
     current_branch = get_current_branch(directory)
     if current_branch is None:
@@ -548,6 +548,21 @@ def create_branch(branch, orphaned=False, changeto=False, directory=None):
     finally:
         if current_branch is not None:
             checkout(current_branch, directory=directory)
+
+
+def ensure_git_root():
+    """
+    Checks that you are in the root of the git repository, else exit.
+
+    :raises: SystemExit if this is not a valid git repository.
+    :raises: SystemExit if not in the root of a git repository.
+    """
+    root = get_root()
+    if root is None:
+        error("Not in a git repository.", exit=True)
+    if os.getcwd() != root:
+        error("Must call from the top folder of the git repository",
+              exit=True)
 
 
 def get_root(directory=None):


### PR DESCRIPTION
Error message:

```
⚪ git bloom-patch export
sh: 0: getcwd() failed: No such file or directory
fatal: Unable to read current working directory: No such file or directory
Traceback (most recent call last):
  File "/wg/stor5/pmathieu/repos/bloom/bloom/commands/git/patch/patch_main.py", line 49, in main
    retcode = args.func(args) or 0
  File "/wg/stor5/pmathieu/repos/bloom/bloom/commands/git/patch/export_cmd.py", line 85, in main
    return export_patches()
  File "/wg/stor5/pmathieu/repos/bloom/bloom/logging.py", line 164, in decorated
    return f(*args, **kwds)
  File "/wg/stor5/pmathieu/repos/bloom/bloom/commands/git/patch/export_cmd.py", line 65, in export_patches
    checkout(current_branch, directory=directory)
  File "/wg/stor5/pmathieu/repos/bloom/bloom/git.py", line 275, in checkout
    if reference == get_current_branch(directory):
  File "/wg/stor5/pmathieu/repos/bloom/bloom/git.py", line 584, in get_current_branch
    output = check_output(cmd, shell=True, cwd=directory)
  File "/wg/stor5/pmathieu/repos/bloom/bloom/util.py", line 281, in check_output
    raise CalledProcessError(p.returncode, cmd)
CalledProcessError: Command 'git branch --no-color' returned non-zero exit status 128
```
