### PR TITLE
Fix return value of git.checkout

### DIFF
--- a/bloom/git.py
+++ b/bloom/git.py
@@ -274,7 +274,7 @@ def checkout(reference, raise_exc=False, directory=None, show_git_status=True):
     debug("Checking out to " + str(reference))
     if reference == get_current_branch(directory):
         debug("Requested checkout reference is the same as the current branch")
-        return 0
+        return True
     fail_msg = ''
     git_root = get_root(directory)
     if git_root is not None:


### PR DESCRIPTION
The rest of the function returns either True or False.
git would return an error code 0 in this case, which corresponds to True here.
