### PR TITLE
old version detector gives false positive on first run after update

### DIFF
--- a/bloom/commands/update.py
+++ b/bloom/commands/update.py
@@ -78,7 +78,7 @@ def check_for_updates():
             return
         version_dict = json.loads(raw)
         os.remove(user_bloom)  # Remove only on successful parse
-        if type(version_dict) == dict and len(version_dict) == 2:
+        if type(version_dict) == dict and len(version_dict) == 2 and version_dict['current'] == bloom.__version__:
             warning(UPDATE_MSG.format(**version_dict))
 
 


### PR DESCRIPTION
```
tfoote@BigFoote:~/work/bloom$ sudo apt-get install python-bloom
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following packages were automatically installed and are no longer required:
  ipmitool libmongo-client0 ruby1.8-dev python-clearsilver libogre-1.7.4 realpath gcc-avr binutils-avr libxslt1-dev python-epydoc
  libgstreamer-plugins-base0.10-dev ruby-facets libregexp-assemble-perl rubygems liblua5.1-0-dev libtar0 libqwt5-qt4 rake mongodb-clients
  libestools2.1 libnl-dev omniorb-nameserver gforth python-all libqt4-core libmongo-client-dev libqwt6 beep collada-dom-dev
  libgstreamer0.10-dev python-scapy python-libpcap libomnithread3-dev festlex-cmu libreadline6-dev ruby1.8 libprotobuf-dev
  collada-dom2.4-dp-base apt-file hostapd python-qt4-gl ruby sysstat festvox-kallpc16k avr-libc libpcsclite-dev libesd0 libreadline5
  openipmi omniidl libogre-dev python-mechanize hddtemp esound-common python-twisted-web2 libspnav-dev spacenavd omniorb libopenipmi0
  collada-dom2.4-dp-dev mongodb-server libomnithread3c2 libffcall1 libspnav0 libnl1 gforth-lib rubygems1.8 festival libomniorb4-1
  festlex-poslex liblist-moreutils-perl gforth-common python-qwt5-qt4 ruby-nokogiri libruby1.8 mongodb-dev libomniorb4-dev libprotoc-dev
  libprotobuf-lite7 python-pysqlite2 libconfig-file-perl udhcpc libtar-dev libqwt-dev libaudiofile1 libreadline-dev
Use 'apt-get autoremove' to remove them.
The following packages will be upgraded:
  python-bloom
1 upgraded, 0 newly installed, 0 to remove and 139 not upgraded.
Need to get 62.1 kB of archives.
After this operation, 167 kB disk space will be freed.
Get:1 http://packages.ros.org/ros-shadow-fixed/ubuntu/ precise/main python-bloom all 0.3.3-1 [62.1 kB]
Fetched 62.1 kB in 0s (223 kB/s)      
(Reading database ... 297142 files and directories currently installed.)
Preparing to replace python-bloom 0.3.2-1 (using .../python-bloom_0.3.3-1_all.deb) ...
Unpacking replacement python-bloom ...
Processing triggers for python-support ...
Setting up python-bloom (0.3.3-1) ...
Processing triggers for python-support ...
tfoote@BigFoote:~/work/bloom$ bloom-release -h
usage: bloom-release [-h] [--list-tracks] [--non-interactive]
                     [--ros-distro ROS_DISTRO] [--new-track] [--pretend]
                     repository [track]

Releases a repository which already exists in the ROS distro file.

positional arguments:
  repository            repository to run bloom on
  track                 track to run

optional arguments:
  -h, --help            show this help message and exit
  --list-tracks, -l     list available tracks for repository
  --non-interactive, -y
  --ros-distro ROS_DISTRO, -r ROS_DISTRO
                        determines the ROS distro file used
  --new-track, -n       if used, a new track will be created before running
                        bloom
  --pretend, -p         Pretends to push and release
This version of bloom is '0.3.2', but the newest available version is '0.3.3'. Please update.
tfoote@BigFoote:~/work/bloom$ bloom-release -h
usage: bloom-release [-h] [--list-tracks] [--non-interactive]
                     [--ros-distro ROS_DISTRO] [--new-track] [--pretend]
                     repository [track]

Releases a repository which already exists in the ROS distro file.

positional arguments:
  repository            repository to run bloom on
  track                 track to run

optional arguments:
  -h, --help            show this help message and exit
  --list-tracks, -l     list available tracks for repository
  --non-interactive, -y
  --ros-distro ROS_DISTRO, -r ROS_DISTRO
                        determines the ROS distro file used
  --new-track, -n       if used, a new track will be created before running
                        bloom
  --pretend, -p         Pretends to push and release
```
