### PR TITLE
Debian package python-bloom should specify the correct version of dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ setup(
     include_package_data=True,
     install_requires=[
         'empy',
-        'PyYAML >= 3.09',
-        'argparse >= 1.2.1',
+        'PyYAML',
+        'argparse',
         'rosdep >= 0.10.3',
         'rospkg >= 1.0.6',
         'vcstools >= 0.1.22',

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,4 +1,4 @@
 [DEFAULT]
-Depends: python-yaml, python-empy, python-argparse, python-rosdep, python-rospkg, python-vcstools, python-distribute, python-catkin-pkg
-Suite: lucid oneiric precise quantal raring
+Depends: python-yaml, python-empy, python-argparse, python-rosdep>=0.10.3, python-rospkg>=1.0.6, python-vcstools>=0.1.22, python-distribute, python-catkin-pkg>=0.1.10
+Suite: lucid oneiric precise quantal
 XS-Python-Version: >= 2.6


### PR DESCRIPTION
Installing or updating python-bloom on Ubuntu will not update its dependencies correctly. E.g. after updating, it throws the error `pkg_resources.DistributionNotFound: catkin-pkg>=0.1.10` 

By explicitly stating the version of the ependencies python-catkin-pkg, python-rospkg, python-rosdep, and python-vcstools in the .deb they would automatically get pulled in after an update. 
