### PR TITLE
bloom-release fails due to missing ~/.netrc

### DIFF
--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -318,10 +318,10 @@ def open_pull_request(track, repository, distro, distro_file_url=ROS_DISTRO_FILE
         if 'github.com' in host:
             gh_username = netrc_hosts[host][0]
             gh_password = netrc_hosts[host][2]
-        if None in [gh_username, gh_password]:
-            error("Either github username or github password is not set in the netrc.")
-            warning("Skipping the pull request...")
-            return
+    if None in [gh_username, gh_password]:
+        error("Either the github username or github password is not set in the ~/.netrc file.")
+        warning("Skipping the pull request...")
+        return
     # Check for fork
     info(fmt("@{bf}@!==> @|@!Checking for rosdistro fork on github..."))
     gh_user_repos = fetch_github_api('https://api.github.com/users/{0}/repos'.format(gh_username))


### PR DESCRIPTION
After the step "git push --tags" bloom 0.3.3 is apparently trying to create a pull request but fails due to a missing file ~./netrc:

```
==> Generating pull request to distro file located at 'https://raw.github.com/ros/rosdistro/master/releases/hydro.yaml'
Unified diff for the ROS distro file located at '/tmp/tmpRgSK_1/octomap-1.5.90-0.patch':
[...]
Failed to parse ~/.netrc file: [Errno 2] No such file or directory: '/home/hornunga/.netrc'
Skipping the pull request...
<== No pull request opened.
```

I guess it should just skip over the missing file if it's not critical (if it is, then this should be documented somewhere).

The output should be more clear if this means that the complete release step should be repeated or if the pull request at the end is only optional, and can be neglected.
