### PR TITLE
When pushing upstream into release-branch symbolic links are changed into the refered files/directories.

### DIFF
--- a/test/system_tests/test_catkin_groovy_release.py
+++ b/test/system_tests/test_catkin_groovy_release.py
@@ -66,8 +66,9 @@ def create_upstream_repository(packages, directory=None):
                     f.write(package_xml)
                 user('touch .cproject')
                 user('touch .project')
-                user('mkdir -p include')
+                user('mkdir -p include/sym')
                 user('touch include/{0}.h'.format(package))
+                os.symlink('../{0}.h'.format(package), 'include/sym/{0}.h'.format(package))
                 user('git add package.xml .cproject .project include')
         user('git commit -m "Releasing version 0.1.0" --allow-empty')
         user('git tag 0.1.0 -m "Releasing version 0.1.0"')
@@ -121,6 +122,7 @@ def _test_unary_package_repository(release_dir, version, directory=None):
         ### Make patch
         ###
         with inbranch('release/groovy/foo'):
+            assert os.path.islink('include/sym/foo.h'), "Symbolic link lost during pipeline"
             if os.path.exists('include/foo.h'):
                 user('git rm include/foo.h')
             else:


### PR DESCRIPTION
When bloom pushes the upstream-branch into it's release branch it automatically changes symbolic links into the files/directories which the symbolic links referred to. 

This is an urgent bug as it leads to roslisp no longer compiling on the build-farms for Fuerte. As a result several packages that rely on roslisp are also no longer available as debians for Fuerte.

The behaviour can be seen in the last commit (March, 5th) in the release-branch of ros_comm for fuerte:
https://github.com/ros-gbp/ros_comm-release/tree/debian/fuerte/precise/ros_comm

The commits that contains the wrong changes has the commit-message "Rebase from 'upstream'". The development branch for fuerte can be found here:
https://github.com/ros-gbp/ros_comm-release/tree/debian/fuerte/precise/ros_comm

Background: The buildsystem of roslisp (asdf) relies on a directory ASDF to be in every lisp-package in ROS (also roslisp itself). Each oft these ASDF directories has to hold symbolic links to *.asd-files which describe the dependencies of the lisp-systems. The lisp-compiler expects these asd-files to always reside in the same directory as the lisp-source files. When these symbolic links are changed into the real *.asd-files in the ASDF-directory compilation of breaks. For roslisp, this directory can be found in the sub-folder clients/roslisp of the development repo.
