### PR TITLE
bloom should allow an alternative "push" url for the repository

### DIFF
--- a/bloom/commands/git/config.py
+++ b/bloom/commands/git/config.py
@@ -70,7 +70,8 @@ template_entry_order = [
     'release_tag',
     'devel_branch',
     'ros_distro',
-    'patches'
+    'patches',
+    'release_repo_url'
 ]
 
 

--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -407,12 +407,6 @@ def create_pull_request(org, repo, user, password, base_branch, head_branch, tit
 def perform_release(repository, track, distro, new_track, interactive, pretend):
     release_repo = get_release_repo(repository, distro)
     with change_directory(release_repo.get_path()):
-        # Check for push permissions
-        try:
-            info(fmt("@{gf}@!==> @|Testing for push permission on release repository"))
-            check_output('git push', shell=True)
-        except subprocess.CalledProcessError:
-            error("Cannot push to remote release repository.", exit=True)
         # Check to see if the old bloom.conf exists
         if check_for_bloom_conf(repository):
             # Convert to a track
@@ -459,8 +453,34 @@ def perform_release(repository, track, distro, new_track, interactive, pretend):
             track = tracks[0]
         # Ensure the track is complete
         track_dict = tracks_dict['tracks'][track]
-        update_track(track_dict)
+        track_dict = update_track(track_dict)
         tracks_dict['tracks'][track] = track_dict
+        # Set the release repositories' remote if given
+        release_repo_url = track_dict.get('release_repo_url', None)
+        if release_repo_url is not None:
+            info(fmt("@{gf}@!==> @|") +
+                 "Setting release repository remote url to '{0}'"
+                 .format(release_repo_url))
+            cmd = 'git remote set-url origin ' + release_repo_url
+            info(fmt("@{bf}@!==> @|@!") + str(cmd))
+            try:
+                subprocess.check_call(cmd, shell=True)
+            except subprocess.CalledProcessError:
+                error("Setting the remote url failed, exiting.", exit=True)
+        # Check for push permissions
+        try:
+            info(fmt(
+                "@{gf}@!==> @|Testing for push permission on release repository"
+            ))
+            cmd = 'git remote -v'
+            info(fmt("@{bf}@!==> @|@!") + str(cmd))
+            subprocess.check_call(cmd, shell=True)
+            cmd = 'git push'
+            info(fmt("@{bf}@!==> @|@!") + str(cmd))
+            subprocess.check_call(cmd, shell=True)
+        except subprocess.CalledProcessError:
+            error("Cannot push to remote release repository.", exit=True)
+        # Write the track config before releasing
         write_tracks_dict_raw(tracks_dict)
         # Run the release
         info(fmt("@{gf}@!==> @|") +

--- a/bloom/config.py
+++ b/bloom/config.py
@@ -112,6 +112,17 @@ of this folder will be overlaid onto the upstream branch after each
 import-upstream.  Additionally, any package.xml files found in the
 overlay will have the :{version} string replaced with the current
 version being released.'''
+    },
+    'release_repo_url': {
+        '<url>': '''\
+(optional) Used when pushing to remote release repositories. This is only
+needed when the release uri which is in the rosdistro file is not writable.
+This is useful, for example, when a releaser would like to use a ssh url
+to push rather than a https:// url.
+''',
+    ':{none}': '''\
+This indicates that the default release url should be used.
+'''
     }
 }
 
@@ -161,6 +172,7 @@ DEFAULT_TEMPLATE = {
     'devel_branch': PromptEntry('Upstream Devel Branch', spec=config_spec['devel_branch']),
     'patches': PromptEntry('Patches Directory', spec=config_spec['patches']),
     'ros_distro': PromptEntry('ROS Distro', default='groovy', spec=config_spec['ros_distro']),
+    'release_repo_url': PromptEntry('Release Repository Push URL', spec=config_spec['release_repo_url']),
     'release_inc': -1,
     'actions': [
         'bloom-export-upstream :{vcs_local_uri} :{vcs_type}'


### PR DESCRIPTION
The rosdistro file should always reference the https version of the url so that the build farm can always clone it (the ssh url can only be cloned if the cloner can authenticate with an ssh key).

This is a problem for users who do not use a ~/.netrc file as it prompts them at each push (three per release). Therefore bloom should provide an option in the release repository which allows the user to set a custom push url which is potentially different from the repository url in the rosdistro file.

Related issues:
#136
#132

https://github.com/ros/rosdistro/pull/676
