### PR TITLE
running bloom with --new-track didn't change behavior

### DIFF
--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -425,14 +425,15 @@ def perform_release(repository, track, distro, new_track, interactive, pretend):
         if new_track:
             if not track:
                 error("You must specify a track when creating a new one.", exit=True)
-            overrides = {'ros_distro': distro}
             if track in tracks_dict['tracks']:
                 warning("Track '{0}' exists, editing instead...".format(track))
                 edit_track_cmd(track)
+                tracks_dict = get_tracks_dict_raw()
             else:
                 # Create a new track called <track>,
                 # copying an existing track if possible,
                 # and overriding the ros_distro
+                overrides = {'ros_distro': distro}
                 new_track_cmd(track, copy_track='', overrides=overrides)
                 tracks_dict = get_tracks_dict_raw()
         if track and track not in tracks_dict['tracks']:


### PR DESCRIPTION
A was trying to rerelease common_msgs into hydro, but have forked from groovy.  

I ran with --new-track and changed the devel-branch to hydro-devel at the prompt but it didn't take when bloom continued. 

It worked afterwords when I just updated the bloom config file to set the devel-branch to hydro-devel in the repo. 

Note 1.9.15 is in groovy-devel 1.9.16 is in hydro-devel. 

```
tfoote@BigFoote:~/work/common_msgs$ bloom-release --ros-distro hydro common_msgs hydro --new-track
==> Fetching 'common_msgs' repository from 'https://github.com/ros-gbp/common_msgs-release.git'
==> Testing for push permission on release repository
Everything up-to-date
Track 'hydro' exists, editing instead...
Repository Name:
  upstream
    Default value, leave this as upstream if you are unsure
  <name>
    Name of the repository (used in the archive name)
  ['upstream']:
Upstream Repository URI:
  <uri>
    Any valid URI. This variable can be templated, for example an svn url
    can be templated as such: "https://svn.foo.com/foo/tags/foo-:{version}"
    where the :{version} token will be replaced with the version for this release.
  ['git@github.com:ros/common_msgs.git']:
Upstream VCS Type:
  svn
    Upstream URI is a svn repository
  git
    Upstream URI is a git repository
  hg
    Upstream URI is a hg repository
  tar
    Upstream URI is a tarball
  ['git']:
Version:
  :{ask}
    This means that the user will be prompted for the version each release.
    This also means that the upstream devel will be ignored.
  :{auto}
    This means the version will be guessed from the devel branch.
    This means that the devel branch must be set, the devel branch must exist,
    and there must be a valid package.xml in the upstream devel branch.
  <version>
    This will be the version used.
    It must be updated for each new upstream version.
  [':{auto}']:
Release Tag:
  :{none}
    For svn and tar only you can set the release tag to :{none}, so that
    it is ignored.  For svn this means no revision number is used.
  :{ask}
    This means the user will be prompted for the release tag on each release.
  :{version}
    This means that the release tag will match the :{version} tag.
    This can be further templated, for example: "foo-:{version}" or "v:{version}"

    This can describe any vcs reference. For git that means {tag, branch, hash},
    for hg that means {tag, branch, hash}, for svn that means a revision number.
    For tar this value doubles as the sub directory (if the repository is
    in foo/ of the tar ball, putting foo here will cause the contents of
    foo/ to be imported to upstream instead of foo itself).
  [':{version}']:
Upstream Devel Branch:
  <vcs reference>
    Branch in upstream repository on which to search for the version.
    This is used only when version is set to ':{auto}'.
  [None]: hydro-devel
ROS Distro:
  <ROS distro>
    This can be any valid ROS distro, e.g. groovy, hydro
  ['hydro']:
Patches Directory:
  <path in bloom branch>
    This can be any valid relative path in the bloom branch. The contents
    of this folder will be overlaid onto the upstream branch after each
    import-upstream.  Additionally, any package.xml files found in the
    overlay will have the :{version} string replaced with the current
    version being released.
  [None]:
Saving 'hydro' track.
==> Releasing 'common_msgs' using release track 'hydro'
==> git-bloom-release hydro
Processing release track settings for 'hydro'
Checking upstream devel branch for a package.xml(s) or stack.xml
Looking for packages in 'groovy-devel' branch... found 10 packages.
Detected version '1.9.15' from package(s): ['nav_msgs', 'shape_msgs', 'stereo_msgs', 'actionlib_msgs', 'trajectory_msgs', 'sensor_msgs', 'geometry_msgs', 'visualization_msgs', 'diagnostic_msgs', 'common_msgs']

Executing release track 'hydro'
==> bloom-export-upstream /tmp/tmpUa72p9/upstream git --tag 1.9.15 --display-uri git@github.com:ros/common_msgs.git --name upstream --output-dir /tmp/tmpgKWxK1
Checking out repository at 'git@github.com:ros/common_msgs.git' to reference '1.9.15'.
Exporting to archive: '/tmp/tmpgKWxK1/upstream-1.9.15.tar.gz'
md5: 363eec2fcbcf4068dc514174caed0eb7

==> git-bloom-import-upstream /tmp/tmpgKWxK1/upstream-1.9.15.tar.gz  --release-version 1.9.15 --replace
+++ Cloning working copy for safety
The latest upstream tag in the release repository is 'upstream/1.9.15'.
Removing tag: 'upstream/1.9.15'
Importing archive into upstream branch...
Creating tag: 'upstream/1.9.15'
<== Command successful, committing changes to working copy
Everything up-to-date
Total 0 (delta 0), reused 0 (delta 0)
To file:///tmp/tmp2zNVxW
 * [new tag]         upstream/1.9.15 -> upstream/1.9.15
I'm happy.  You should be too.

==> git-bloom-generate -y rosrelease hydro --source upstream -i 1
+++ Cloning working copy for safety
WARNING: Metapackage "common_msgs" must buildtool_depend on catkin.
Invalid metapackage:
  Metapackage 'common_msgs': No buildtool dependency on catkin

Refusing to release invalid metapackage 'common_msgs', metapackage requirements:
  http://ros.org/reps/rep-0127.html#metapackage
<== Error running command 'git-bloom-generate -y rosrelease hydro --source upstream -i 1'
Release failed, exiting.

```
