### PR TITLE
bloom-export-upstream does not accept a tarball as input

### DIFF
--- a/bloom/commands/git/release.py
+++ b/bloom/commands/git/release.py
@@ -242,6 +242,10 @@ def execute_track(track, track_dict, release_inc, pretend=True, debug=False, fas
     info("", use_prefix=False)
     info("Executing release track '{0}'".format(track))
     for action in track_dict['actions']:
+        if 'bloom-export-upstream' in action and settings['vcs_type'] == 'tar':
+            warning("Explicitly skipping bloom-export-upstream for tar.")
+            settings['archive_path'] = settings['vcs_uri']
+            continue
         templated_action = template_str(action, settings)
         info(fmt("@{bf}@!==> @|@!" + sanitize(str(templated_action))))
         if pretend:


### PR DESCRIPTION
(bloom 0.3.5)

After configuring a release repository like this:

```
$ git-bloom-config edit groovy
Repository Name:
  upstream
    Default value, leave this as upstream if you are unsure
  <name>
    Name of the repository (used in the archive name)
  ['upstream']: 
Upstream Repository URI:
  <uri>
    Any valid URI. This variable can be templated, for example an svn url
    can be templated as such: "https://svn.foo.com/foo/tags/foo-:{version}"
    where the :{version} token will be replaced with the version for this release.
  ['https://google-glog.googlecode.com/files/glog-:{version}.tar.gz']: 
Upstream VCS Type:
  svn
    Upstream URI is a svn repository
  git
    Upstream URI is a git repository
  hg
    Upstream URI is a hg repository
  tar
    Upstream URI is a tarball
  ['tar']: 
Version:
  :{ask}
    This means that the user will be prompted for the version each release.
    This also means that the upstream devel will be ignored.
  :{auto}
    This means the version will be guessed from the devel branch.
    This means that the devel branch must be set, the devel branch must exist,
    and there must be a valid package.xml in the upstream devel branch.
  <version>
    This will be the version used.
    It must be updated for each new upstream version.
  [':{ask}']: 
Release Tag:
  :{none}
    For svn and tar only you can set the release tag to :{none}, so that
    it is ignored.  For svn this means no revision number is used.
  :{ask}
    This means the user will be prompted for the release tag on each release.
  :{version}
    This means that the release tag will match the :{version} tag.
    This can be further templated, for example: "foo-:{version}" or "v:{version}"

    This can describe any vcs reference. For git that means {tag, branch, hash},
    for hg that means {tag, branch, hash}, for svn that means a revision number.
    For tar this value doubles as the sub directory (if the repository is
    in foo/ of the tar ball, putting foo here will cause the contents of
    foo/ to be imported to upstream instead of foo itself).
  [':{version}']: 
Upstream Devel Branch:
  <vcs reference>
    Branch in upstream repository on which to search for the version.
    This is used only when version is set to ':{auto}'.
  [None]: 
ROS Distro:
  <ROS distro>
    This can be any valid ROS distro, e.g. groovy, hydro
  ['groovy']: 
Patches Directory:
  <path in bloom branch>
    This can be any valid relative path in the bloom branch. The contents
    of this folder will be overlaid onto the upstream branch after each
    import-upstream.  Additionally, any package.xml files found in the
    overlay will have the :{version} string replaced with the current
    version being released.
  ['groovy']: 
Saving 'groovy' track.
```

git-bloom-release fails:

```
$ git-bloom-release groovy
Processing release track settings for 'groovy'
What version are you releasing (version should normally be MAJOR.MINOR.PATCH)? 0.3.3

Executing release track 'groovy'
==> bloom-export-upstream https://google-glog.googlecode.com/files/glog-0.3.3.tar.gz tar --tag 0.3.3 --display-uri https://google-glog.googlecode.com/files/glog-0.3.3.tar.gz --name upstream --output-dir /tmp/tmpZgzPa2
usage: bloom-export-upstream [-h] [--tag TAG] [--output-dir OUTPUT_DIR]
                             [--display-uri DISPLAY_URI] [--name NAME] [-d]
                             [--version] [--unsafe]
                             uri {git,hg,svn}
bloom-export-upstream: error: argument type: invalid choice: 'tar' (choose from 'git', 'hg', 'svn')
<== Error running command 'bloom-export-upstream https://google-glog.googlecode.com/files/glog-0.3.3.tar.gz tar --tag 0.3.3 --display-uri https://google-glog.googlecode.com/files/glog-0.3.3.tar.gz --name upstream --output-dir /tmp/tmpZgzPa2'
```
