### PR TITLE
Ability to black list packages in bloom's track config

### DIFF
--- a/bloom/commands/git/release.py
+++ b/bloom/commands/git/release.py
@@ -65,10 +65,11 @@ from bloom.logging import info
 from bloom.logging import sanitize
 from bloom.logging import warning
 
+from bloom.packages import get_package_data
+
 import bloom.util
 from bloom.util import add_global_arguments
 from bloom.util import change_directory
-from bloom.util import get_package_data
 from bloom.util import handle_global_arguments
 
 try:

--- a/bloom/generators/release.py
+++ b/bloom/generators/release.py
@@ -45,8 +45,9 @@ from bloom.logging import fmt
 from bloom.logging import info
 from bloom.logging import warning
 
+from bloom.packages import get_package_data
+
 from bloom.util import execute_command
-from bloom.util import get_package_data
 
 from bloom.commands.git.patch.trim_cmd import trim
 

--- a/bloom/generators/rosrelease.py
+++ b/bloom/generators/rosrelease.py
@@ -6,8 +6,9 @@ from bloom.git import inbranch
 
 from bloom.logging import warning
 
+from bloom.packages import get_package_data
+
 from bloom.util import execute_command
-from bloom.util import get_package_data
 
 
 class RosReleaseGenerator(ReleaseGenerator):

--- a/bloom/packages.py
+++ b/bloom/packages.py
@@ -1,0 +1,103 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2013, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Provides common utility functions for bloom.
+"""
+
+from __future__ import print_function
+
+import os
+import sys
+import traceback
+
+from bloom.git import show
+
+from bloom.config import BLOOM_CONFIG_BRANCH
+
+from bloom.logging import debug
+from bloom.logging import error
+from bloom.logging import info
+from bloom.logging import warning
+
+try:
+    from catkin_pkg.packages import find_packages
+    from catkin_pkg.packages import verify_equal_package_versions
+except ImportError:
+    debug(traceback.format_exc())
+    error("catkin_pkg was not detected, please install it.",
+          file=sys.stderr, exit=True)
+
+
+def get_ignored_packages():
+    data = show(BLOOM_CONFIG_BRANCH, 'packages.ignored') or ''
+    return [p.strip() for p in data.split() if p.strip()]
+
+
+def get_package_data(branch_name=None, directory=None, quiet=True):
+    """
+    Gets package data about the package(s) in the current branch.
+
+    It also ignores the packages in the `packages.ignore` file in the master branch.
+
+    :param branch_name: name of the branch you are searching on (log use only)
+    """
+    log = debug if quiet else info
+    repo_dir = directory or os.getcwd()
+    if branch_name:
+        log("Looking for packages in '{0}' branch... ".format(branch_name), end='')
+    else:
+        log("Looking for packages in '{0}'... ".format(directory or os.getcwd()), end='')
+    ## Check for package.xml(s)
+    packages = find_packages(repo_dir)
+    if type(packages) == dict and packages != {}:
+        if len(packages) > 1:
+            log("found " + str(len(packages)) + " packages.",
+                use_prefix=False)
+        else:
+            log("found '" + packages.values()[0].name + "'.",
+                use_prefix=False)
+        version = verify_equal_package_versions(packages.values())
+        ignored_packages = get_ignored_packages()
+        for k, v in dict(packages).items():
+            if v.name in ignored_packages:
+                warning("Explicitly ignoring package '{0}' because it is in the `packages.ignored` file."
+                        .format(v.name))
+                del packages[k]
+        if packages == {}:
+            error("All packages that were found were also ignored, aborting.",
+                  exit=True)
+        return [p.name for p in packages.values()], version, packages
+    # Otherwise we have a problem
+    log("failed.", use_prefix=False)
+    error("No package.xml(s) found, and '--package-name' not given, aborting.",
+          use_prefix=False, exit=True)

--- a/bloom/util.py
+++ b/bloom/util.py
@@ -43,7 +43,6 @@ import socket
 import sys
 import tempfile
 import time
-import traceback
 import urllib2
 
 from email.utils import formatdate
@@ -60,16 +59,7 @@ from bloom.logging import debug
 from bloom.logging import disable_ANSI_colors
 from bloom.logging import enable_debug
 from bloom.logging import error
-from bloom.logging import info
 from bloom.logging import warning
-
-try:
-    from catkin_pkg.packages import find_packages
-    from catkin_pkg.packages import verify_equal_package_versions
-except ImportError:
-    debug(traceback.format_exc())
-    error("catkin_pkg was not detected, please install it.",
-          file=sys.stderr, exit=True)
 
 
 # Convention: < 0 is a warning exit, 0 is normal, > 0 is an error
@@ -207,35 +197,6 @@ def my_copytree(tree, destination, ignores=None):
             shutil.copy(src, dst)
         else:
             raise RuntimeError("Unknown file type for element: '{0}'".format(src))
-
-
-def get_package_data(branch_name=None, directory=None, quiet=True):
-    """
-    Gets package data about the package(s) in the current branch.
-
-    :param branch_name: name of the branch you are searching on (log use only)
-    """
-    log = debug if quiet else info
-    repo_dir = directory or os.getcwd()
-    if branch_name:
-        log("Looking for packages in '{0}' branch... ".format(branch_name), end='')
-    else:
-        log("Looking for packages in '{0}'... ".format(directory or os.getcwd()), end='')
-    ## Check for package.xml(s)
-    packages = find_packages(repo_dir)
-    if type(packages) == dict and packages != {}:
-        if len(packages) > 1:
-            log("found " + str(len(packages)) + " packages.",
-                use_prefix=False)
-        else:
-            log("found '" + packages.values()[0].name + "'.",
-                use_prefix=False)
-        version = verify_equal_package_versions(packages.values())
-        return [p.name for p in packages.values()], version, packages
-    # Otherwise we have a problem
-    log("failed.", use_prefix=False)
-    error("No package.xml(s) found, and '--package-name' not given, aborting.",
-          use_prefix=False, exit=True)
 
 
 def add_global_arguments(parser):


### PR DESCRIPTION
Releasers should be able to explicitly not release packages from a given repository. For example, `test_foo` might be a package in the repository which shouldn't be released.
