### PR TITLE
KeyError: 'last_version' when running bloom_release

### DIFF
--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -260,7 +260,7 @@ def generate_ros_distro_diff(track, repository, distro):
     # Update the repository
     repo = release_dict['repositories'][repository]
     if 'tags' not in repo:
-        repo['tages'] = {}
+        repo['tags'] = {}
     repo['tags']['release'] = 'release/%s/{package}/{version}' % distro
     repo['version'] = version
     if 'packages' not in repo:


### PR DESCRIPTION
From @aleeper

```
aleeper@ael-w530:/tmp/razer_hydra-release$ bloom-release razer_hydra --track groovy --rosdistro groovy
Specified repository 'razer_hydra' is not in the release file located at 'https://raw.github.com/ros/rosdistro/master/groovy/release.yaml'
Could not determine release repository url for repository 'razer_hydra' of distro 'groovy'
You can continue the release process by manually specifying the location of the RELEASE repository.
To be clear this is the url of the RELEASE repository not the upstream repository.
Release repository url [press enter to abort]: https://github.com/aleeper/razer_hydra-release.git
==> Fetching 'razer_hydra' repository from 'https://github.com/aleeper/razer_hydra-release.git'
Cloning into '/tmp/tmpEyRpg7'...
remote: Counting objects: 8, done.
remote: Compressing objects: 100% (3/3), done.
remote: Total 8 (delta 1), reused 8 (delta 1)
Unpacking objects: 100% (8/8), done.
Traceback (most recent call last):
  File "/usr/bin/bloom-release", line 9, in <module>
    load_entry_point('bloom==0.4.0', 'console_scripts', 'bloom-release')()
  File "/usr/lib/pymodules/python2.7/bloom/commands/release.py", line 763, in main
    args.new_track, not args.non_interactive, args.pretend)
  File "/usr/lib/pymodules/python2.7/bloom/commands/release.py", line 614, in perform_release
    start_summary(track)
  File "/usr/lib/pymodules/python2.7/bloom/commands/release.py", line 489, in start_summary
    last_version = track_dict['last_version']  # Actually current version now
KeyError: 'last_version'

aleeper@ael-w530:/tmp/razer_hydra-release$ 
```
