### PR TITLE
Suppress warnings about transactional safety when running bloom-release

### DIFF
--- a/bloom/commands/git/release.py
+++ b/bloom/commands/git/release.py
@@ -56,6 +56,7 @@ from bloom.git import ensure_clean_working_env
 from bloom.git import ensure_git_root
 from bloom.git import get_current_branch
 from bloom.git import get_root
+from bloom.git import GitClone
 
 from bloom.logging import debug
 from bloom.logging import error
@@ -70,7 +71,9 @@ from bloom.packages import get_package_data
 import bloom.util
 from bloom.util import add_global_arguments
 from bloom.util import change_directory
+from bloom.util import disable_git_clone
 from bloom.util import handle_global_arguments
+from bloom.util import quiet_git_clone_warning
 
 try:
     from vcstools.vcs_abstraction import get_vcs_client
@@ -322,8 +325,16 @@ def main(sysargs=None):
 
     verify_track(args.track, tracks_dict['tracks'][args.track])
 
-    execute_track(args.track, tracks_dict['tracks'][args.track],
-                  args.release_increment, args.pretend, args.debug, args.unsafe)
+    git_clone = GitClone()
+    with git_clone:
+        quiet_git_clone_warning(True)
+        disable_git_clone(True)
+        execute_track(args.track, tracks_dict['tracks'][args.track],
+                      args.release_increment, args.pretend, args.debug,
+                      args.unsafe)
+        disable_git_clone(False)
+        quiet_git_clone_warning(False)
+    git_clone.commit()
 
     # Notify the user of success and next action suggestions
     print('\n\n')

--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -85,10 +85,12 @@ from bloom.summary import get_summary_file
 
 from bloom.util import add_global_arguments
 from bloom.util import change_directory
+from bloom.util import disable_git_clone
 from bloom.util import get_rfc_2822_date
 from bloom.util import handle_global_arguments
 from bloom.util import load_url_to_file_handle
 from bloom.util import maybe_continue
+from bloom.util import quiet_git_clone_warning
 
 try:
     import vcstools.__version__
@@ -762,6 +764,8 @@ def main(sysargs=None):
 
     try:
         os.environ['BLOOM_TRACK'] = args.track
+        disable_git_clone(True)
+        quiet_git_clone_warning(True)
         perform_release(args.repository, args.track, args.ros_distro,
                         args.new_track, not args.non_interactive, args.pretend)
     except (KeyboardInterrupt, EOFError) as exc:

--- a/bloom/git.py
+++ b/bloom/git.py
@@ -55,6 +55,7 @@ from bloom.util import change_directory
 from bloom.util import check_output
 from bloom.util import execute_command
 from bloom.util import get_git_clone_state
+from bloom.util import get_git_clone_state_quiet
 from bloom.util import pdb_hook
 import bloom.util
 
@@ -62,8 +63,10 @@ import bloom.util
 class GitClone(object):
     def __init__(self, directory=None, track_all=True):
         self.disabled = get_git_clone_state()
+        self.disabled_quiet = get_git_clone_state_quiet()
         if self.disabled:
-            warning('Skipping transactional safety mechanism, be careful...')
+            if not self.disabled_quiet:
+                warning('Skipping transactional safety mechanism, be careful...')
             return
         self.tmp_dir = None
         self.directory = directory if directory is not None else os.getcwd()

--- a/bloom/util.py
+++ b/bloom/util.py
@@ -220,17 +220,35 @@ def add_global_arguments(parser):
 _pdb = False
 _quiet = False
 _disable_git_clone = False
+_disable_git_clone_quiet = False
 
 
 def disable_git_clone(state=True):
     global _disable_git_clone
     _disable_git_clone = state
-    os.environ['BLOOM_UNSAFE'] = "1"
+    if state:
+        os.environ['BLOOM_UNSAFE'] = "1"
+    elif 'BLOOM_UNSAFE' in os.environ:
+        del os.environ['BLOOM_UNSAFE']
+
+
+def quiet_git_clone_warning(state=True):
+    global _disable_git_clone_quiet
+    _disable_git_clone_quiet = state
+    if state:
+        os.environ['BLOOM_UNSAFE_QUIET'] = "1"
+    elif 'BLOOM_UNSAFE_QUIET' in os.environ:
+        del os.environ['BLOOM_UNSAFE_QUIET']
 
 
 def get_git_clone_state():
     global _disable_git_clone
     return _disable_git_clone
+
+
+def get_git_clone_state_quiet():
+    global _disable_git_clone_quiet
+    return _disable_git_clone_quiet
 
 
 def handle_global_arguments(args):
@@ -241,6 +259,7 @@ def handle_global_arguments(args):
     if args.no_color:
         disable_ANSI_colors()
     disable_git_clone(args.unsafe or 'BLOOM_UNSAFE' in os.environ)
+    quiet_git_clone_warning('BLOOM_UNSAFE_QUIET' in os.environ)
 
 
 def print_exc(exc):


### PR DESCRIPTION
Currently when you run bloom-release the BLOOM_UNSAFE env variable is being set to speed up releases (since the repo is cloned and only pushed on success there is no need for cloning/pushing on a per command basis). Because of this you get messages like these:

```
Skipping transactional safety mechanism, be careful...
```

It should really only print these when this option is used directly by the user.
