### PR TITLE
auto upgrade of gbp failed

### DIFF
--- a/bloom/commands/git/config.py
+++ b/bloom/commands/git/config.py
@@ -77,7 +77,7 @@ template_entry_order = [
 ]
 
 
-@inbranch(BLOOM_CONFIG_BRANCH)
+@inbranch('bloom')
 def convert_old_bloom_conf(prefix=None):
     prefix = prefix if prefix is not None else 'convert'
     tracks_dict = get_tracks_dict_raw()

--- a/bloom/config.py
+++ b/bloom/config.py
@@ -287,7 +287,8 @@ def upconvert_bloom_to_config_branch():
             ignores = ('.git', '.gitignore', '.svn', '.hgignore', '.hg', 'CVS')
             configs = os.path.join(tmp_dir, 'configs')
             my_copytree(git_root, configs, ignores)
-            execute_command('git rm -rf ./*')
+            if [x for x in os.listdir(os.getcwd()) if x not in ignores]:
+                execute_command('git rm -rf ./*')
             with open(PLACEHOLDER_FILE, 'w') as f:
                 f.write("""\
 This branch ('bloom') has been deprecated in favor of storing settings and overlay files in the master branch.


### PR DESCRIPTION
```
tfoote@BigFoote:~/work/geometry_experimental$ bloom-release geometery_experimental -t hydro -r hydro --new-track
Specified repository 'geometery_experimental' is not in the release file located at 'https://raw.github.com/ros/rosdistro/master/hydro/release.yaml'
Could not determine release repository url for repository 'geometery_experimental' of distro 'hydro'
You can continue the release process by manually specifying the location of the RELEASE repository.
To be clear this is the url of the RELEASE repository not the upstream repository.
Release repository url [press enter to abort]: https://github.com/ros-gbp/geometry_experimental-release.git
==> Fetching 'geometery_experimental' repository from 'https://github.com/ros-gbp/geometry_experimental-release.git'
Cloning into '/tmp/tmpyTdSc1'...
remote: Counting objects: 3136, done.
remote: Compressing objects: 100% (2122/2122), done.
remote: Total 3136 (delta 956), reused 3007 (delta 827)
Receiving objects: 100% (3136/3136), 410.34 KiB | 318 KiB/s, done.
Resolving deltas: 100% (956/956), done.
Old bloom.conf file detected.
==> Converting to bloom.conf to track
Traceback (most recent call last):
  File "/usr/bin/bloom-release", line 9, in <module>
    load_entry_point('bloom==0.4.1', 'console_scripts', 'bloom-release')()
  File "/usr/lib/pymodules/python2.7/bloom/commands/release.py", line 771, in main
    args.new_track, not args.non_interactive, args.pretend)
  File "/usr/lib/pymodules/python2.7/bloom/commands/release.py", line 577, in perform_release
    convert_old_bloom_conf(None if new_track else distro)
  File "/usr/lib/pymodules/python2.7/bloom/git.py", line 325, in decorated
    return f(*args, **kwds)
  File "/usr/lib/pymodules/python2.7/bloom/commands/git/config.py", line 91, in convert_old_bloom_conf
    upstream_repo = check_output(cmd, shell=True).strip()
  File "/usr/lib/pymodules/python2.7/bloom/util.py", line 308, in check_output
    raise CalledProcessError(p.returncode, cmd)
CalledProcessError: Command 'git config -f bloom.conf bloom.upstream' returned non-zero exit status 1

tfoote@BigFoote:~/work/geometry_experimental$ 
```
