### PR TITLE
debian rules files should be made executable

### DIFF
--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -114,6 +114,7 @@ def __place_template_folder(group, src, dst, gbp=False):
             try:
                 debug("Placing template '{0}'".format(template_path))
                 template = pkg_resources.resource_string(group, template_path)
+                template_abs_path = pkg_resources.resource_filename(group, template_path)
             except IOError as err:
                 error("Failed to load template "
                       "'{0}': {1}".format(template_file, str(err)), exit=True)
@@ -124,6 +125,7 @@ def __place_template_folder(group, src, dst, gbp=False):
                 os.remove(template_dst)
             with open(template_dst, 'w') as f:
                 f.write(template)
+            shutil.copystat(template_abs_path, template_dst)
 
 
 def place_template_files(path, gbp=False):


### PR DESCRIPTION
git-buildpackage and dpkg-buildpackage complain about them not being executable.

```
W: ros-hydro-pcl source: out-of-date-standards-version 3.9.2 (current is 3.9.3)
Finished running lintian.

WARNING generated by debuild:
Making debian/rules executable!
```
