### PR TITLE
Lintian errors from bloom generated packages

### DIFF
--- a/bloom/generators/debian/templates/control.em
+++ b/bloom/generators/debian/templates/control.em
@@ -1,7 +1,7 @@
 Source: @(Package)
 Section: misc
 Priority: extra
-Maintainer: "@(Maintainers)"
+Maintainer: @(Maintainer)
 Build-Depends: debhelper (>= 7.0.50~), @(', '.join(BuildDepends))
 Homepage: @(Homepage)
 Standards-Version: 3.9.2


### PR DESCRIPTION
Something like this:

```
E: ros-hydro-eml changes: bad-distribution-in-changes-file raring
E: ros-hydro-eml source: maintainer-address-malformed "Austin Hendrix
<ahendrix@willowgarage.com>"
```

It looks like there is a newline character in the email address, not sure about the raring problem...
