### PR TITLE
Setup environment for the install step

### DIFF
--- a/bloom/generators/debian/templates/rules.em
+++ b/bloom/generators/debian/templates/rules.em
@@ -50,3 +50,10 @@ override_dh_shlibdeps:
 	# set things like CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
 	dh_shlibdeps -l$(CURDIR)/debian/@(Package)/@(InstallationPrefix)/lib/
+
+override_dh_auto_install:
+        # In case we're installing to a non-standard location, look for a setup.sh
+        # in the install tree that was dropped by catkin, and source it.  It will
+        # set things like CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
+        if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
+        dh_auto_install


### PR DESCRIPTION
This is a showstopper I can't workaround for gradle relayed builds. Without this, it can't find it's plugins. Any reason it should not use the catkin setup environment?

Tested this with a locally installed bloom and a locally built deb.
