### PR TITLE
bloom-release fails if the release repo is not empty

### DIFF
--- a/bloom/commands/git/patch/rebase_cmd.py
+++ b/bloom/commands/git/patch/rebase_cmd.py
@@ -37,19 +37,15 @@ def non_git_rebase(upstream_branch, directory=None):
             ignores = ('.git', '.gitignore', '.svn', '.hgignore', '.hg', 'CVS')
             parent_source = os.path.join(tmp_dir, 'parent_source')
             my_copytree(git_root, parent_source, ignores)
-
-        # Clear out the local branch
-        execute_command('git rm -rf *', cwd=directory)
-        # Collect .* files (excluding .git)
-        dot_items = []
+        # Collect files (excluding .git)
+        items = []
         for item in os.listdir(git_root):
             if item in ['.git', '..', '.']:
                 continue
-            if item.startswith('.'):
-                dot_items.append(item)
-        # Remove and .* files missed by 'git rm -rf *'
-        if len(dot_items) > 0:
-            execute_command('git rm -rf ' + ' '.join(dot_items), cwd=directory)
+            items.append(item)
+        # Remove all files
+        if len(items) > 0:
+            execute_command('git rm -rf ' + ' '.join(items), cwd=directory)
         # Clear out any untracked files
         execute_command('git clean -fdx', cwd=directory)  # for good measure?
 

--- a/bloom/commands/git/patch/trim_cmd.py
+++ b/bloom/commands/git/patch/trim_cmd.py
@@ -94,18 +94,15 @@ def _trim(config, force, directory):
         sub_dir = os.path.join(git_root, config['trim'])
         storage = os.path.join(tmp_dir, config['trim'])
         shutil.copytree(sub_dir, storage)
-        # Clear out the git repo
-        execute_command('git rm -rf ./*', cwd=directory)
-        # Collect .* files (excluding .git)
-        dot_items = []
+        # Collect al files (excluding .git)
+        items = []
         for item in os.listdir(git_root):
             if item in ['.git', '..', '.']:
                 continue
-            if item.startswith('.'):
-                dot_items.append(item)
+            items.append(item)
         # Remove and .* files missed by 'git rm -rf *'
-        if len(dot_items) > 0:
-            execute_command('git rm -rf ' + ' '.join(dot_items), cwd=directory)
+        if len(items) > 0:
+            execute_command('git rm -rf ' + ' '.join(items), cwd=directory)
         # Clear out any untracked files
         execute_command('git clean -fdx', cwd=directory)
         # Copy the sub directory back


### PR DESCRIPTION
This is happening consistently. It's a multipackage release with a metapackage. When I try to release to an empty repostory (I delete the release repo and create it again) the command

```
bloom-release --track hydro --rosdistro hydro sr_ronex --edit
```

works correctly and all the release branches are uploaded to

https://github.com/shadow-robot/sr-ronex-release.git

But after this (with a populated release repo) when I try to run bloom-release for a second time (either with the same version or with a subsequent version) it fails complaining about a call to 

git rm -rf *

The failure seems to happen always with the second package in the Releasing packages: [...] list. This list doesn't always appear in the same order, and I have observed the failure in two different packages (that were in the second position at that time).

This might suggest some kind of cleanup issue after processing the first package.

```
bloom-release --track hydro --rosdistro hydro sr_ronex
==> Fetching 'sr_ronex' repository from 'https://github.com/shadow-robot/sr-ronex-release.git'
Cloning into '/tmp/tmpswSTIC'...
remote: Counting objects: 1032, done.
remote: Compressing objects: 100% (619/619), done.
remote: Total 1032 (delta 316), reused 1029 (delta 316)
Receiving objects: 100% (1032/1032), 257.55 KiB | 427 KiB/s, done.
Resolving deltas: 100% (316/316), done.
==> Testing for push permission on release repository
==> git remote -v
origin  https://github.com/shadow-robot/sr-ronex-release.git (fetch)
origin  https://github.com/shadow-robot/sr-ronex-release.git (push)
==> git push --dry-run
Username for 'https://github.com': toliver
Password for 'https://toliver@github.com': 
Everything up-to-date
==> Releasing 'sr_ronex' using release track 'hydro'
==> git-bloom-release hydro
Processing release track settings for 'hydro'
Checking upstream devel branch for package.xml(s)
Cloning into '/tmp/tmpEeTpa5/upstream'...
remote: Counting objects: 2922, done.
remote: Compressing objects: 100% (1310/1310), done.
remote: Total 2922 (delta 1573), reused 2840 (delta 1491)
Receiving objects: 100% (2922/2922), 1006.44 KiB | 558 KiB/s, done.
Resolving deltas: 100% (1573/1573), done.
Looking for packages in 'hydro' branch... found 10 packages.
Detected version '0.9.3' from package(s): ['sr_ronex_drivers', 'sr_ronex_hardware_interface', 'sr_ronex_utilities', 'sr_ronex_msgs', 'sr_ronex_transmissions', 'sr_ronex_launch', 'sr_ronex_controllers', 'sr_ronex_external_protocol', 'sr_ronex', 'sr_ronex_examples']

Executing release track 'hydro'
==> bloom-export-upstream /tmp/tmpEeTpa5/upstream git --tag 0.9.3 --display-uri https://github.com/shadow-robot/sr-ronex.git --name sr_ronex --output-dir /tmp/tmpT4kknD
Checking out repository at 'https://github.com/shadow-robot/sr-ronex.git' to reference '0.9.3'.
Exporting to archive: '/tmp/tmpT4kknD/sr_ronex-0.9.3.tar.gz'
md5: 4cd4dcabfc6f4ddfd9d2b92eaad4e40b

==> git-bloom-import-upstream /tmp/tmpT4kknD/sr_ronex-0.9.3.tar.gz  --release-version 0.9.3 --replace
The latest upstream tag in the release repository is 'upstream/0.9.3'.
Removing tag: 'upstream/0.9.3'
Importing archive into upstream branch...
Creating tag: 'upstream/0.9.3'
I'm happy.  You should be too.

==> git-bloom-generate -y rosrelease hydro --source upstream -i 1
Releasing packages: ['sr_ronex_drivers', 'sr_ronex_hardware_interface', 'sr_ronex_utilities', 'sr_ronex_msgs', 'sr_ronex_transmissions', 'sr_ronex_launch', 'sr_ronex_controllers', 'sr_ronex_external_protocol', 'sr_ronex', 'sr_ronex_examples']
Releasing package 'sr_ronex_drivers' for 'hydro' to: 'release/hydro/sr_ronex_drivers'
Releasing package 'sr_ronex_hardware_interface' for 'hydro' to: 'release/hydro/sr_ronex_hardware_interface'
 [git-bloom-patch rebase]: 'execute_command' failed to call 'git rm -rf *' which had a return code (128):
 [git-bloom-patch rebase]: \`\`\`
fatal: pathspec 'bin' did not match any files

 [git-bloom-patch rebase]: \`\`\`
Traceback (most recent call last):
  File "/usr/lib/pymodules/python2.7/bloom/commands/git/generate.py", line 101, in try_execute
    retcode = func(*args, **kwargs)
  File "/usr/lib/pymodules/python2.7/bloom/logging.py", line 210, in decorated
    return f(*args, **kwds)
  File "/usr/lib/pymodules/python2.7/bloom/commands/git/patch/rebase_cmd.py", line 146, in rebase_patches
    non_git_rebase(config['parent'], directory=directory)
  File "/usr/lib/pymodules/python2.7/bloom/commands/git/patch/rebase_cmd.py", line 42, in non_git_rebase
    execute_command('git rm -rf *', cwd=directory)
  File "/usr/lib/pymodules/python2.7/bloom/util.py", line 388, in execute_command
    raise CalledProcessError(result, cmd)
CalledProcessError: Command 'git rm -rf *' returned non-zero exit status 128

Error calling git-bloom-patch rebase: Command 'git rm -rf *' returned non-zero exit status 128
git-bloom-patch rebase returned exit code (128)
<== Error running command '['/usr/bin/git-bloom-generate', '-y', 'rosrelease', 'hydro', '--source', 'upstream', '-i', '1']'
Release failed, exiting.
```
