### PR TITLE
Failed to open pull request: KeyError - 'release'

### DIFF
--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -274,6 +274,8 @@ def generate_ros_distro_diff(track, repository, distro):
     if repository not in distribution_dict['repositories']:
         global _user_provided_release_url
         distribution_dict['repositories'][repository] = {}
+    # Create a release entry if there isn't already one
+    if 'release' not in distribution_dict['repositories'][repository]:
         distribution_dict['repositories'][repository]['release'] = {
             'url': _user_provided_release_url
         }


### PR DESCRIPTION
I am trying to release my package (which I have already indexed it for doc generation) and I get this, when `bloom-release` attempts to automatically open a pull request on rosdistro:

```
Failed to open pull request: KeyError - 'release'
```

This is what I get at the end of the file `~/.bloom_logs/bloom-release_current-date.log`:

```
[debug] /tmp/tmpIUPSBY:$ git ls-tree master:tracks.yaml
[debug] /tmp/tmpIUPSBY:$ git show master:tracks.yaml
[debug] Traceback (most recent call last):
  File "/usr/lib/pymodules/python2.7/bloom/commands/release.py", line 767, in perform_release
    pull_request_url = open_pull_request(track, repository, distro, ssh_pull_request)
  File "/usr/lib/pymodules/python2.7/bloom/commands/release.py", line 418, in open_pull_request
    updated_distribution_file = generate_ros_distro_diff(track, repository, distro)
  File "/usr/lib/pymodules/python2.7/bloom/commands/release.py", line 281, in generate_ros_distro_diff
    repo = distribution_dict['repositories'][repository]['release']
KeyError: 'release'

[error] Failed to open pull request: KeyError - 'release'
[error] SYS.EXIT
```

Related question on [answers.ros.org](http://answers.ros.org/question/126781/bloom-release-failed-to-open-pull-request/).
