### PR TITLE
fix #196 for good

### DIFF
--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -313,6 +313,34 @@ def generate_substitutions_from_package(
     data['changelogs'] = changelogs
     # Summarize dependencies
     summarize_dependency_mapping(data, depends, build_depends, resolved_deps)
+
+    def convertToUnicode(obj):
+        if sys.version_info.major == 2:
+            if isinstance(obj, str):
+                return unicode(obj.decode('utf8'))
+            elif isinstance(obj, unicode):
+                return obj
+        else:
+            if isinstance(obj, bytes):
+                return str(obj.decode('utf8'))
+            elif isinstance(obj, str):
+                return obj
+        if isinstance(obj, list):
+            for i, val in enumerate(obj):
+                obj[i] = convertToUnicode(val)
+            return obj
+        elif isinstance(obj, type(None)):
+            return None
+        elif isinstance(obj, tuple):
+            obj_tmp = list(obj)
+            for i, val in enumerate(obj_tmp):
+                obj_tmp[i] = convertToUnicode(obj_tmp[i])
+            return tuple(obj_tmp)
+        raise RuntimeError('need to deal with type %s' % (str(type(obj))))
+
+    for item in data.items():
+        data[item[0]] = convertToUnicode(item[1])
+
     return data
 
 


### PR DESCRIPTION
so, 89a778d77f17bc54beeeea7379fa658ec31cfe79 fixed part of the problem but I still got:

```
Traceback (most recent call last):
  File "/usr/bin/git-bloom-generate", line 9, in <module>
    load_entry_point('bloom==0.4.9', 'console_scripts', 'git-bloom-generate')()
  File "/usr/lib/pymodules/python2.7/bloom/commands/git/generate.py", line 247, in main
    run_generator(generator, args)
  File "/usr/lib/pymodules/python2.7/bloom/commands/git/generate.py", line 162, in run_generator
    gen.post_rebase, destination)
  File "/usr/lib/pymodules/python2.7/bloom/commands/git/generate.py", line 101, in try_execute
    retcode = func(*args, **kwargs)
  File "/usr/lib/pymodules/python2.7/bloom/generators/debian/generator.py", line 520, in post_rebase
    data = self.generate_debian(package, distro)
  File "/usr/lib/pymodules/python2.7/bloom/generators/debian/generator.py", line 647, in generate_debian
    template_files = process_template_files('.', subs)
  File "/usr/lib/pymodules/python2.7/bloom/generators/debian/generator.py", line 359, in process_template_files
    return __process_template_folder(debian_dir, subs)
  File "/usr/lib/pymodules/python2.7/bloom/generators/debian/generator.py", line 343, in __process_template_folder
    result = em.expand(template, **subs)
  File "/usr/lib/pymodules/python2.7/em.py", line 3017, in expand
    result = interpreter.expand(_data, _locals)
  File "/usr/lib/pymodules/python2.7/em.py", line 2210, in expand
    self.string(data, '<expand>', locals)
  File "/usr/lib/pymodules/python2.7/em.py", line 2369, in string
    self.safe(scanner, True, locals)
  File "/usr/lib/pymodules/python2.7/em.py", line 2379, in safe
    self.parse(scanner, locals)
  File "/usr/lib/pymodules/python2.7/em.py", line 2399, in parse
    token.run(self, locals)
  File "/usr/lib/pymodules/python2.7/em.py", line 1336, in run
    interpreter.write(str(result))
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 2: ordinal not in range(128)
```

when trying to release `map_msgs` (Stephane has an accent in his name).
My patch makes things work.
