### PR TITLE
Add rpm templates to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include bloom/generators/debian/templates *
+recursive-include bloom/generators/rpm/templates *


### PR DESCRIPTION
setup.py install did not install rpm templates. Fix this by adding relevant directory to MANIFEST.in.
