### PR TITLE
Make license tags required for RPMs

### DIFF
--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -209,9 +209,9 @@ def generate_substitutions_from_package(
     data['Version'] = package.version
     data['Description'] = rpmify_string(package.description)
     # License
-    data['License'] = package.licenses[0] if package.licenses else ''
-    if data['License'] == '':
-        warning("No license set")
+    if not package.licenses or not package.licenses[0]:
+        error("No license set for package '{0}', aborting.".format(package.name), exit=True)
+    data['License'] = package.licenses[0]
     # Websites
     websites = [str(url) for url in package.urls if url.type == 'website']
     data['Homepage'] = websites[0] if websites else ''

--- a/bloom/generators/rpm/templates/template.spec.em
+++ b/bloom/generators/rpm/templates/template.spec.em
@@ -4,7 +4,8 @@ Release:        @(RPMInc)%{?dist}
 Summary:        ROS @(Name) package
 
 Group:          Development/Libraries
-@[if License and License != '']License:        @(License)@\n@[end if]@[if Homepage and Homepage != '']URL:            @(Homepage)@\n@[end if]Source0:        %{name}-%{version}.tar.gz
+License:        @(License)
+@[if Homepage and Homepage != '']URL:            @(Homepage)@\n@[end if]Source0:        %{name}-%{version}.tar.gz
 
 @[for p in Depends]Requires:       @p@\n@[end for]@[for p in BuildDepends]BuildRequires:  @p@\n@[end for]@[for p in Conflicts]Conflicts:      @p@\n@[end for]@[for p in Replaces]Obsoletes:      @p@\n@[end for]
 %description


### PR DESCRIPTION
Source RPMs will not build if the license tag is empty or missing. This will not be a problem for the vast majority of packages in ROS.
