### PR TITLE
Unicode fixes for RPM generation

### DIFF
--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -271,6 +271,38 @@ def generate_substitutions_from_package(
     data['changelogs'] = changelogs
     # Summarize dependencies
     summarize_dependency_mapping(data, depends, build_depends, resolved_deps)
+
+    def convertToUnicode(obj):
+        if sys.version_info.major == 2:
+            if isinstance(obj, str):
+                return unicode(obj.decode('utf8'))
+            elif isinstance(obj, unicode):
+                return obj
+        else:
+            if isinstance(obj, bytes):
+                return str(obj.decode('utf8'))
+            elif isinstance(obj, str):
+                return obj
+        if isinstance(obj, list):
+            for i, val in enumerate(obj):
+                obj[i] = convertToUnicode(val)
+            return obj
+        elif isinstance(obj, type(None)):
+            return None
+        elif isinstance(obj, tuple):
+            obj_tmp = list(obj)
+            for i, val in enumerate(obj_tmp):
+                obj_tmp[i] = convertToUnicode(obj_tmp[i])
+            return tuple(obj_tmp)
+        elif isinstance(obj, int):
+            return obj
+        elif isinstance(obj, int):
+            return obj
+        raise RuntimeError('need to deal with type %s' % (str(type(obj))))
+
+    for item in data.items():
+        data[item[0]] = convertToUnicode(item[1])
+
     return data
 
 
@@ -297,7 +329,7 @@ def __process_template_folder(path, subs):
         result = em.expand(template, **subs)
         # Write the result
         with open(template_path, 'w') as f:
-            f.write(result.encode('utf8'))
+            f.write(result)
         # Copy the permissions
         shutil.copymode(item, template_path)
         processed_items.append(item)


### PR DESCRIPTION
Includes debian generation fixes for 32305ba99a0eddb106c75b97dcd2c559af0769bb and f213ec199c7a47e5ed1ce4ce695d723a65fd13d2 and fixes https://github.com/ros-infrastructure/bloom/issues/196 for RPMs as well.

I know we've talked about it before, but we should merge the common code between debian and RPM generation, or at the very least start putting functions like this in a common file.

In any case, this will fix it for now.
