### PR TITLE
Set CMAKE_INSTALL_LIBDIR explicitly when building Debian packages

### DIFF
--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -267,6 +267,8 @@ def generate_substitutions_from_package(
     data['Package'] = sanitize_package_name(package.name)
     # Installation prefix
     data['InstallationPrefix'] = installation_prefix
+    # Library directory location
+    data['LibDir'] = None
     # Resolve dependencies
     depends = package.run_depends
     build_depends = package.build_depends + package.buildtool_depends

--- a/bloom/generators/debian/templates/rules.em
+++ b/bloom/generators/debian/templates/rules.em
@@ -16,6 +16,9 @@ export DH_OPTIONS=-v --buildsystem=cmake
 export LDFLAGS=
 export PKG_CONFIG_PATH=@(InstallationPrefix)/lib/pkgconfig
 
+@[if LibDir is not None]export CMAKE_ADDITIONAL_FLAGS="-DCMAKE_INSTALL_LIBDIR='@(LibDir)'"@[end if]
+
+
 %:
 	dh  $@@
 
@@ -25,9 +28,11 @@ override_dh_auto_configure:
 	# set things like CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
 	dh_auto_configure -- \
-		-DCATKIN_BUILD_BINARY_PACKAGE="1" \
-		-DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" \
-		-DCMAKE_PREFIX_PATH="@(InstallationPrefix)"
+		-DCATKIN_BUILD_BINARY_PACKAGE="1"		\
+		-DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)"	\
+		-DCMAKE_PREFIX_PATH="@(InstallationPrefix)"	\
+		$(CMAKE_ADDITIONAL_FLAGS)
+
 
 override_dh_auto_build:
 	# In case we're installing to a non-standard location, look for a setup.sh

--- a/bloom/generators/rosdebian.py
+++ b/bloom/generators/rosdebian.py
@@ -113,6 +113,8 @@ def get_subs(pkg, os_name, os_version, ros_distro):
         ros_distro
     )
     subs['Package'] = rosify_package_name(subs['Package'], ros_distro)
+    # Override LibDir to not use multiarch with ROS releases
+    subs['LibDir'] = 'lib'
     return subs
 
 


### PR DESCRIPTION
When building ROS Debian packages, the library directory must be lib,
not lib/ARCH.
