### PR TITLE
RPM support for architecture independent flags

### DIFF
--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -268,6 +268,8 @@ def generate_substitutions_from_package(
                 package.maintainers[0].email
             )
         ))
+    exported_tags = [e.tagname for e in package.exports]
+    data['NoArch'] = 'metapackage' in exported_tags or 'architecture_independent' in exported_tags
     data['changelogs'] = changelogs
     # Summarize dependencies
     summarize_dependency_mapping(data, depends, build_depends, resolved_deps)

--- a/bloom/generators/rpm/templates/template.spec.em
+++ b/bloom/generators/rpm/templates/template.spec.em
@@ -6,7 +6,7 @@ Summary:        ROS @(Name) package
 Group:          Development/Libraries
 License:        @(License)
 @[if Homepage and Homepage != '']URL:            @(Homepage)@\n@[end if]Source0:        %{name}-%{version}.tar.gz
-
+@[if NoArch]@\nBuildArch:      noarch@\n@[end if]
 @[for p in Depends]Requires:       @p@\n@[end for]@[for p in BuildDepends]BuildRequires:  @p@\n@[end for]@[for p in Conflicts]Conflicts:      @p@\n@[end for]@[for p in Replaces]Obsoletes:      @p@\n@[end for]
 %description
 @(Description)


### PR DESCRIPTION
No metapackages contain any architecture-specific information, so we can mark them as "noarch" packages. This means that the generated package is installable on any architecture system, and theoretically eliminates the need to generate the RPM for more than one arch.

The current buildfarm infrastructure will not be able to take advantage of this, mainly because non-metapackages can depend on metapackages, and if the package is noarch, it could trigger rebuild of arches other than the one that triggered it to build. This is really a buildfarm issue, and isn't worth discussing here.

Another key advantage of noarch RPMs is that they don't generate a debuginfo package, as there are no symbols associated with any of their contents (if there are symbols, it is not noarch...two way implication).

Right now, I determine if a package is noarch by looking at if it is a metapackage. Are there any additional reasons that a package would certainly not contain any arch-specific code? Could/Should a flag be added to the `package.xml` for indicating that your package is not architecture-specific? This would include any python-exclusive packages, so it would likely be a large part of ROS.

This PR is ready to be merged, but I'm still looking for further thoughts...

Thanks!

--scott
