### PR TITLE
include buildtool_export_depends explicitly with run_depends

### DIFF
--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -268,7 +268,7 @@ def generate_substitutions_from_package(
     # Installation prefix
     data['InstallationPrefix'] = installation_prefix
     # Resolve dependencies
-    depends = package.run_depends
+    depends = package.run_depends + package.buildtool_export_depends
     build_depends = package.build_depends + package.buildtool_depends + package.test_depends
     unresolved_keys = depends + build_depends
     resolved_deps = resolve_dependencies(unresolved_keys, os_name,

--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -224,7 +224,7 @@ def generate_substitutions_from_package(
     # Installation prefix
     data['InstallationPrefix'] = installation_prefix
     # Resolve dependencies
-    depends = package.run_depends
+    depends = package.run_depends + package.buildtool_export_depends
     build_depends = package.build_depends + package.buildtool_depends + package.test_depends
     unresolved_keys = depends + build_depends + package.replaces + package.conflicts
     resolved_deps = resolve_dependencies(unresolved_keys, os_name,


### PR DESCRIPTION
When generating architecture specific packages for Debian and Fedora we need to include the `buildtool_export_depends` (empty if package.xml version == 1) with the `run_depends`.

The `buildtool_export_depends` should not be included into `run_depends` implicitly like `build_export_depends` and `exec_depends` are in `catkin_pkg.package.Package`, but instead should only be used in this particular packaging case.
