### PR TITLE
Fix second call to bloom-release on a svn repo

### DIFF
--- a/bloom/commands/git/patch/rebase_cmd.py
+++ b/bloom/commands/git/patch/rebase_cmd.py
@@ -37,6 +37,8 @@ def non_git_rebase(upstream_branch, directory=None):
             ignores = ('.git', '.gitignore', '.svn', '.hgignore', '.hg', 'CVS')
             parent_source = os.path.join(tmp_dir, 'parent_source')
             my_copytree(git_root, parent_source, ignores)
+        # Clear out any untracked files
+        execute_command('git clean -fdx', cwd=directory)  # for good measure?
         # Collect files (excluding .git)
         items = []
         for item in os.listdir(git_root):
@@ -46,8 +48,6 @@ def non_git_rebase(upstream_branch, directory=None):
         # Remove all files
         if len(items) > 0:
             execute_command('git rm -rf ' + ' '.join(items), cwd=directory)
-        # Clear out any untracked files
-        execute_command('git clean -fdx', cwd=directory)  # for good measure?
 
         # Copy the parent source into the newly cleaned directory
         my_copytree(parent_source, git_root)

--- a/bloom/commands/git/patch/trim_cmd.py
+++ b/bloom/commands/git/patch/trim_cmd.py
@@ -94,6 +94,8 @@ def _trim(config, force, directory):
         sub_dir = os.path.join(git_root, config['trim'])
         storage = os.path.join(tmp_dir, config['trim'])
         shutil.copytree(sub_dir, storage)
+        # Clear out any untracked files
+        execute_command('git clean -fdx', cwd=directory)
         # Collect al files (excluding .git)
         items = []
         for item in os.listdir(git_root):
@@ -103,8 +105,6 @@ def _trim(config, force, directory):
         # Remove and .* files missed by 'git rm -rf *'
         if len(items) > 0:
             execute_command('git rm -rf ' + ' '.join(items), cwd=directory)
-        # Clear out any untracked files
-        execute_command('git clean -fdx', cwd=directory)
         # Copy the sub directory back
         for item in os.listdir(storage):
             src = os.path.join(storage, item)


### PR DESCRIPTION
On multi-package SVN repositories, the first release works, but I could consistently make the 2nd one fail.

`````` bash
==> git-bloom-generate -y rosrelease hydro --source upstream -i 0
Releasing packages: ['foo', 'bar']
Releasing package 'foo' for 'hydro' to: 'release/hydro/foo'
Releasing package 'bar' for 'hydro' to: 'release/hydro/bar'
 [git-bloom-patch trim]: 'execute_command' failed to call 'git rm -rf foo bar src' which had a return code (128):
 [git-bloom-patch trim]: ```
fatal: pathspec 'src' did not match any files

 [git-bloom-patch trim]: ```
Traceback (most recent call last):
  File "/home/paulmathieu/github/bloom/bloom/commands/git/generate.py", line 101, in try_execute
    retcode = func(*args, **kwargs)
  File "/home/paulmathieu/github/bloom/bloom/generators/release.py", line 129, in post_rebase
    return trim(trim_d)
  File "/home/paulmathieu/github/bloom/bloom/logging.py", line 211, in decorated
    return f(*args, **kwds)
  File "/home/paulmathieu/github/bloom/bloom/commands/git/patch/trim_cmd.py", line 177, in trim
    new_config = _trim(new_config, force, directory)
  File "/home/paulmathieu/github/bloom/bloom/commands/git/patch/trim_cmd.py", line 105, in _trim
    execute_command('git rm -rf ' + ' '.join(items), cwd=directory)
  File "/home/paulmathieu/github/bloom/bloom/util.py", line 434, in execute_command
    raise CalledProcessError(result, cmd)
CalledProcessError: Command 'git rm -rf foo bar src' returned non-zero exit status 128

Error calling generator post_rebase: Command 'git rm -rf foo bar src' returned non-zero exit status 128
generator post_rebase returned exit code (128)
<== Error running command '['/usr/local/bin/git-bloom-generate', '-y', 'rosrelease', 'hydro', '--source', 'upstream', '-i', '0']'
``````

While I have not investigated the reason why the release repo ends up being dirty, running `git clean` _before_ `git rm` fixes the problem.
