### PR TITLE
Correctly set install prefix for 'bloom-generate rosdebian'

### DIFF
--- a/bloom/generators/rosdebian.py
+++ b/bloom/generators/rosdebian.py
@@ -110,7 +110,8 @@ def get_subs(pkg, os_name, os_version, ros_distro):
         pkg,
         os_name,
         os_version,
-        ros_distro
+        ros_distro,
+        RosDebianGenerator.default_install_prefix + ros_distro
     )
     subs['Package'] = rosify_package_name(subs['Package'], ros_distro)
     return subs


### PR DESCRIPTION
Currently the installation prefix is set to /usr for 'bloom-generate
rosdebian', even though the documentation states that it will be
/opt/ros/<rosdistro>. This also means that the debian packages can't be
built, as the pkgconfig path is wrong.
