### PR TITLE
Fix changelog order in RPM generator

### DIFF
--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -43,6 +43,7 @@ import traceback
 import textwrap
 
 from dateutil import tz
+from time import strptime
 
 from bloom.generators import BloomGenerator
 from bloom.generators import resolve_dependencies
@@ -255,7 +256,9 @@ def generate_substitutions_from_package(
     data['Maintainers'] = ', '.join(maintainers)
     # Changelog
     if releaser_history:
-        sorted_releaser_history = sorted(releaser_history, key=releaser_history.get, reverse=True)
+        sorted_releaser_history = sorted(releaser_history,
+                                         key=lambda k: strptime(releaser_history.get(k)[0], '%a %b %d %Y'),
+                                         reverse=True)
         changelogs = [(v, releaser_history[v]) for v in sorted_releaser_history]
     else:
         # Ensure at least a minimal changelog


### PR DESCRIPTION
It looks like I misunderstood `{}.get(k)`, and thought it was sorting by key or something. In any case, the current behavior sorts by the date _alphabetically_, which is obviously wrong. This throws an error in SRPM build. Instead of sorting by version number (which I believe was my original intent), we should sort by date. The SRPM build cares more that the changelog is chronological by date, less so about the versions associated with each changelog entry.
