### PR TITLE
added a check: release_repo != upstream_repo

### DIFF
--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -214,6 +214,7 @@ def get_repo_uri(repository, distro):
         info("You can continue the release process by manually specifying the location of the RELEASE repository.")
         info("To be clear this is the url of the RELEASE repository not the upstream repository.")
         info("For release repositories on github, you should provide the `https://` url which should end in `.git`.")
+        info("Here is the url for a typical release repository on GitHub: https://github.com/ros-gbp/rviz-release.git")
         while True:
             try:
                 url = safe_input('Release repository url [press enter to abort]: ')
@@ -963,6 +964,15 @@ def perform_release(repository, track, distro, new_track, interactive, pretend, 
                       str(tracks), exit=True)
             # Get the only track
             track = tracks[0]
+        # Make sure the release repository and the upstream repository are different.
+        track_dict = tracks_dict['tracks'][track]
+        vcs_uri = track_dict.get('vcs_uri')
+        if vcs_uri == release_repo.get_url():
+            warning("Your RELEASE repository, '{0}', is the same as your UPSTREAM repository, '{1}'."
+                    .format(release_repo.get_url(), vcs_uri))
+            warning("This is not recommended, normally you have separate RELEASE and UPSTREAM repositories.")
+            if not maybe_continue('n', 'Are you sure you want continue'):
+                error("User quit.", exit=True)
         start_summary(track)
         if not pull_request_only:
             _perform_release(repository, track, distro, new_track, interactive, pretend, tracks_dict)


### PR DESCRIPTION
Now it looks like this (using `https://github.com/wjwwood/not_available_on_fedora.git` as an example):

```
% bloom-release -r hydro -t hydro not_available_on_fedora -n
Specified repository 'not_available_on_fedora' is not in the distribution file located at 'https://raw.github.com/ros/rosdistro/master/hydro/distribution.yaml'
Could not determine release repository url for repository 'not_available_on_fedora' of distro 'hydro'
You can continue the release process by manually specifying the location of the RELEASE repository.
To be clear this is the url of the RELEASE repository not the upstream repository.
For release repositories on github, you should provide the `https://` url which should end in `.git`.
Here is the url for a typical release repository on GitHub: https://github.com/ros-gbp/rviz-release.git
Release repository url [press enter to abort]: https://github.com/wjwwood/not_available_on_fedora.git
==> Fetching 'not_available_on_fedora' repository from 'https://github.com/wjwwood/not_available_on_fedora.git'
[ ... ]
Upstream Repository URI:
  <uri>
    Any valid URI. This variable can be templated, for example an svn url
    can be templated as such: "https://svn.foo.com/foo/tags/foo-:{version}"
    where the :{version} token will be replaced with the version for this release.
  [None]: https://github.com/wjwwood/not_available_on_fedora.git
[ ... ]
Created 'hydro' track.
Your RELEASE repository, 'https://github.com/wjwwood/not_available_on_fedora.git', is the same as your UPSTREAM repository, 'https://github.com/wjwwood/not_available_on_fedora.git'.
This is not recommended, normally you have separate RELEASE and UPSTREAM repositories.
Are you sure you want continue [y/N]? [I pressed enter]
User quit.
```

This check happens a little late in the run, because you don't know the intended upstream until after a track has been created. But it still happens before anything is pushed.

See: #267
