### PR TITLE
Open pull requests against specific commit

### DIFF
--- a/bloom/github.py
+++ b/bloom/github.py
@@ -137,6 +137,15 @@ class Github(object):
             repos.extend(new_repos)
             page += 1
 
+    def get_branch(self, owner, repo, branch):
+        url = '/repos/{owner}/{repo}/branches/{branch}'.format(**locals())
+        resp = do_github_get_req(url, auth=self.auth)
+        if '{0}'.format(resp.status) not in ['200']:
+            raise GithubException("Failed to get branch information for '{branch}' on '{owner}/{repo}' using '{url}'"
+                                  .format(**locals()),
+                                  resp)
+        return json.loads(resp.read())
+
     def list_branches(self, owner, repo, start_page=None):
         page = start_page or 1
         branches = []


### PR DESCRIPTION
There is a race condition for creating a pull requests where the rosdistro repo changes between calculating the diff and opening the pull request. This pull request attempts to remove this condition by capturing the commit hash of the branch and repo from which the rosdistro index came from. Then this commit hash is specifically used as the base of the pull request. This might cause the pull request to not be able to be merged, but should prevent the cases described in https://github.com/ros-infrastructure/bloom/issues/252
