### PR TITLE
Fixed exception when importing bloom.logging

### DIFF
--- a/bloom/logging.py
+++ b/bloom/logging.py
@@ -300,7 +300,7 @@ try:
         _file_log.write("[bloom] bloom version " + bloom.__version__ + "\n")
 except Exception as exc:
     _file_log = None
-    debug(str(exc.__name__) + ": " + str(exc))
+    debug(str(exc.__class__.__name__) + ": " + str(exc))
 
 _summary_file = None
 


### PR DESCRIPTION
There is incorrect exception-handling code in `bloom.logging` that throws an exception as soon as it is imported. This is a very annoying problem since `bloom.logging` is included in all of the command-line scripts.

The error looks like this:

```
$ bloom-generate 
Traceback (most recent call last):
  File "/usr/local/bin/bloom-generate", line 9, in <module>
    load_entry_point('bloom==0.5.12', 'console_scripts', 'bloom-generate')()
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources.py", line 339, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources.py", line 2457, in load_entry_point
    return ep.load()
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources.py", line 2171, in load
    ['__name__'])
  File "/usr/local/lib/python2.7/dist-packages/bloom/commands/__init__.py", line 42, in <module>
    from bloom.commands.update import start_updater
  File "/usr/local/lib/python2.7/dist-packages/bloom/commands/update.py", line 49, in <module>
    from bloom.logging import warning
  File "/usr/local/lib/python2.7/dist-packages/bloom/logging.py", line 303, in <module>
    debug(str(exc.__name__) + ": " + str(exc))
```

This caused by a bug in how the error message is constructed: it uses `__name__` instead of `__class__.__name__`. This only happens if writing a file log fails, e.g. because the logging directory is not writable.
