### PR TITLE
fix blank lines that can appear in the Debian template

### DIFF
--- a/bloom/generators/debian/templates/control.em
+++ b/bloom/generators/debian/templates/control.em
@@ -2,10 +2,8 @@ Source: @(Package)
 Section: misc
 Priority: extra
 Maintainer: @(Maintainer)
-Build-Depends: debhelper (>= @(debhelper_version).0.0), @(', '.join(BuildDepends))
-@[if Conflicts]Conflicts: @(', '.join(Conflicts))@\n@[end if]
-@[if Replaces]Replaces: @(', '.join(Replaces))@\n@[end if]
-Homepage: @(Homepage)
+Build-Depends: debhelper (>= @(debhelper_version).0.0), @(', '.join(BuildDepends))@[if Conflicts]@\nConflicts: @(', '.join(Conflicts))@[end if]
+@[if Replaces]Replaces: @(', '.join(Replaces))@\n@[end if]Homepage: @(Homepage)
 Standards-Version: 3.9.2
 
 Package: @(Package)


### PR DESCRIPTION
that was tested on a package with a replace and one without (naoqi_bridge and romeo_robot)
