### PR TITLE
Consider multiple distribution files with REP-143

### DIFF
--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -210,7 +210,15 @@ def get_index():
 def get_distribution_file(distro):
     global _rosdistro_distribution_files
     if distro not in _rosdistro_distribution_files:
-        _rosdistro_distribution_files[distro] = rosdistro.get_distribution_file(get_index(), distro)
+        try:
+            # REP 143, get list of distribution files and take the last one
+            files = rosdistro.get_distribution_files(get_index(), distro)
+            if not files:
+                error("No distribution files listed for distribution '{0}'."
+                      .format(distro), exit=True)
+            _rosdistro_distribution_files[distro] = files[-1]
+        except AttributeError:
+            _rosdistro_distribution_files[distro] = rosdistro.get_distribution_file(get_index(), distro)
     return _rosdistro_distribution_files[distro]
 
 _rosdistro_distribution_file_urls = {}


### PR DESCRIPTION
With REP-143 (https://github.com/ros-infrastructure/rep/pull/87) there can be multiple distribution files, so bloom with try to use the new api in rosdistro (https://github.com/ros-infrastructure/rosdistro/pull/45) to get a list of the distribution files and then take the last one. Otherwise it will fall back to the current rosdistro API, so this change is backwards compatible.
