### PR TITLE
python3 compatibility patch for urlparse import

### DIFF
--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -57,7 +57,11 @@ try:
 except ImportError:
     from http.client import HTTPSConnection
 
-from urlparse import urlparse
+# python2/3 compatibility
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 
 import bloom
 


### PR DESCRIPTION
This one instance looks to be the only remaining instance of this import not patched. 
