### PR TITLE
RPM fixes as well as key error recovery fix

### DIFF
--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -77,6 +77,7 @@ from bloom.commands.git.patch.common import set_patch_config
 
 from bloom.packages import get_package_data
 
+from bloom.util import code
 from bloom.util import to_unicode
 from bloom.util import execute_command
 from bloom.util import get_rfc_2822_date
@@ -594,8 +595,8 @@ class DebianGenerator(BloomGenerator):
             error("You can try to address the issues which appear above and try again if you wish.")
             try:
                 if not maybe_continue(msg="Would you like to try again?"):
-                    error("User aborted after rosdep keys were not resolved.",
-                          exit=True)
+                    error("User aborted after rosdep keys were not resolved.")
+                    sys.exit(code.GENERATOR_NO_ROSDEP_KEY_FOR_DISTRO)
             except (KeyboardInterrupt, EOFError):
                 error("\nUser quit.", exit=True)
             update_rosdep()

--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -43,6 +43,7 @@ import traceback
 import textwrap
 
 from dateutil import tz
+from distutils.version import LooseVersion
 from time import strptime
 
 from bloom.generators import BloomGenerator
@@ -258,6 +259,8 @@ def generate_substitutions_from_package(
     # Changelog
     if releaser_history:
         sorted_releaser_history = sorted(releaser_history,
+                                         key=lambda k: LooseVersion(k), reverse=True)
+        sorted_releaser_history = sorted(sorted_releaser_history,
                                          key=lambda k: strptime(releaser_history.get(k)[0], '%a %b %d %Y'),
                                          reverse=True)
         changelogs = [(v, releaser_history[v]) for v in sorted_releaser_history]

--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -79,6 +79,7 @@ from bloom.commands.git.patch.common import set_patch_config
 
 from bloom.packages import get_package_data
 
+from bloom.util import code
 from bloom.util import to_unicode
 from bloom.util import execute_command
 from bloom.util import maybe_continue
@@ -534,8 +535,8 @@ class RpmGenerator(BloomGenerator):
             error("You can try to address the issues which appear above and try again if you wish.")
             try:
                 if not maybe_continue(msg="Would you like to try again?"):
-                    error("User aborted after rosdep keys were not resolved.",
-                          exit=True)
+                    error("User aborted after rosdep keys were not resolved.")
+                    sys.exit(code.GENERATOR_NO_ROSDEP_KEY_FOR_DISTRO)
             except (KeyboardInterrupt, EOFError):
                 error("\nUser quit.", exit=True)
             update_rosdep()


### PR DESCRIPTION
Three things:

1. Fixed another changelog sort issue in the RPM generator (present in `jsk_model_tools`)
2. Applied @wjwwood's rosdep key patch to the RPM generator
3. Fixed the `rosdep` key patch exit code as to not break https://github.com/ros-infrastructure/bloom/pull/308, which relies on a specific exit code indicating a `rosdep` key issue.