### PR TITLE
Extend debian generator to split pkg description into <synopsis, long description>

### DIFF
--- a/test/unit_tests/test_generators/test_debian/test_generator.py
+++ b/test/unit_tests/test_generators/test_debian/test_generator.py
@@ -4,6 +4,7 @@ from ....utils.common import redirected_stdio
 
 from bloom.generators.debian.generator import em
 from bloom.generators.debian.generator import get_changelogs
+from bloom.generators.debian.generator import format_description
 
 from catkin_pkg.packages import find_packages
 
@@ -24,3 +25,21 @@ def test_unicode_templating():
         chlogs = get_changelogs(packages['bad_changelog_pkg'])
         template = "@(changelog)"
         em.expand(template, {'changelog': chlogs[0][2]})
+
+
+def test_format_description():
+    assert '' == format_description('')
+    assert '.' == format_description('.')
+    assert 'Word.' == format_description('Word.')
+    assert 'Word' == format_description('Word')
+    assert '.' == format_description(' .')
+    assert '.' == format_description(' . ')
+    assert 'Word.\n Other words.' == format_description('Word. Other words.')
+    assert 'The first sentence, or synopsis.\n The second sentence. Part of the long description, but all in a single paragraph.' == format_description('The first sentence, or synopsis. The second sentence. Part of the long description, but all in a single paragraph.')
+    assert '..' == format_description('..')
+    assert 'The my_package package' == format_description('The my_package package')
+    assert 'First sentence with a version nr: 2.4.5, some other text.\n And then some other text.' == format_description('First sentence with a version nr: 2.4.5, some other text. And then some other text.')
+    assert 'More punctuation! This will split here.\n And the rest.' == format_description('More punctuation! This will split here. And the rest.')
+    assert 'v1.2.3 with v5.3.7 and ! Split after this.\n Long description here.' == format_description('v1.2.3 with v5.3.7 and ! Split after this. Long description here.\n\n')
+    # no whitespace between <p>'s, no split
+    assert 'some embedded html markup.the other sentence.' == format_description('<h1>some embedded</h1>\n<p>html markup.</p><p>the other sentence.</p>')


### PR DESCRIPTION
Small change that formats the text in the `Description` field of the `control` file such that the first sentence will be treated as the synopsis (or short description) by `apt` and related tools. The rest of the package description is added as a single, large paragraph (as it is now).

All nose tests still pass, and I've added some new ones.

A more fancy version of `format_description()` could perform a proper conversion of embedded newlines or `<p>` tags in package descriptions, but I thought to start with this first.

Context: [Support for 'short description' in package.xml / Bloom?](http://answers.ros.org/question/112886/support-for-short-description-in-packagexml-bloom/).
