### PR TITLE
put the Conflicts and Replaces fields in the nongeneraal section

### DIFF
--- a/bloom/generators/debian/templates/control.em
+++ b/bloom/generators/debian/templates/control.em
@@ -3,12 +3,12 @@ Section: misc
 Priority: extra
 Maintainer: @(Maintainer)
 Build-Depends: debhelper (>= @(debhelper_version).0.0), @(', '.join(BuildDepends))
-@[if Conflicts]Conflicts: @(', '.join(Conflicts))@\n@[end if]@
-@[if Replaces]Replaces: @(', '.join(Replaces))@\n@[end if]@
 Homepage: @(Homepage)
 Standards-Version: 3.9.2
 
 Package: @(Package)
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, @(', '.join(Depends))
+@[if Conflicts]Conflicts: @(', '.join(Conflicts))@\n@[end if]@
+@[if Replaces]Replaces: @(', '.join(Replaces))@\n@[end if]@
 Description: @(Description)


### PR DESCRIPTION
If you do:
```
git clone git@github.com:ros-naoqi/naoqi_bridge-release.git
git checkout debian/ros-jade-naoqi-driver_0.4.7-0_vivid
git-buildpackage -uc -us --git-ignore-branch --git-ignore-new
```

You get this warning during the build:
```
dpkg-gencontrol: warning: unknown information field 'Conflicts' in input data in general section of control info file
```

And indeed:
```
dpkg -I ../ros-jade-naoqi-driver_0.4.7-0vivid_amd64.deb
```
does not show any conflicts info.

Nothing bad, it's just that the generated package will not conflict / replace what you want. This fixes it.