### PR TITLE
Manually specify lib dir in RPM spec file

### DIFF
--- a/bloom/generators/rpm/templates/template.spec.em
+++ b/bloom/generators/rpm/templates/template.spec.em
@@ -26,6 +26,7 @@ mkdir -p obj-%{_target_platform} && cd obj-%{_target_platform}
         -USYSCONF_INSTALL_DIR \
         -USHARE_INSTALL_PREFIX \
         -ULIB_SUFFIX \
+        -DCMAKE_INSTALL_LIBDIR="lib" \
         -DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" \
         -DCMAKE_PREFIX_PATH="@(InstallationPrefix)" \
         -DSETUPTOOLS_DEB_LAYOUT=OFF \


### PR DESCRIPTION
This will only affect those `CMakeLists.txt` which use `GNUInstallDirs`.

This is breaking `fcl` on Fedora, because `libccd` (which is already a Fedora package, by the way) is getting installed to `/opt/ros/foo/lib64` on `x86_64` systems. This is incorrect, as ROS *always* uses `/opt/ros/foo/lib` on all architectures.