### PR TITLE
Generate debian debug packages

### DIFF
--- a/bloom/generators/debian/templates/control.em
+++ b/bloom/generators/debian/templates/control.em
@@ -17,5 +17,5 @@ Package: @(Package)-dbg
 Architecture: any
 Section: debug
 Priority: extra
-Depends: @(Package) (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
+Depends: @(Package) (= ${binary:Version}), ${misc:Depends}
 Description: Debug symbols for @(Package)

--- a/bloom/generators/debian/templates/control.em
+++ b/bloom/generators/debian/templates/control.em
@@ -12,3 +12,10 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, @(', '.join(Depends))
 @[if Conflicts]Conflicts: @(', '.join(Conflicts))@\n@[end if]@
 @[if Replaces]Replaces: @(', '.join(Replaces))@\n@[end if]@
 Description: @(Description)
+
+Package: @(Package)-dbg
+Architecture: any
+Section: debug
+Priority: extra
+Depends: @(Package) (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
+Description: Debug symbols for @(Package)

--- a/bloom/generators/debian/templates/rules.em
+++ b/bloom/generators/debian/templates/rules.em
@@ -30,8 +30,7 @@ override_dh_auto_configure:
 	dh_auto_configure -- \
 		-DCATKIN_BUILD_BINARY_PACKAGE="1" \
 		-DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" \
-		-DCMAKE_PREFIX_PATH="@(InstallationPrefix)" \
-		-DCMAKE_BUILD_TYPE=RelWithDebInfo
+		-DCMAKE_PREFIX_PATH="@(InstallationPrefix)"
 
 override_dh_auto_build:
 	# In case we're installing to a non-standard location, look for a setup.sh

--- a/bloom/generators/debian/templates/rules.em
+++ b/bloom/generators/debian/templates/rules.em
@@ -30,7 +30,8 @@ override_dh_auto_configure:
 	dh_auto_configure -- \
 		-DCATKIN_BUILD_BINARY_PACKAGE="1" \
 		-DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" \
-		-DCMAKE_PREFIX_PATH="@(InstallationPrefix)"
+		-DCMAKE_PREFIX_PATH="@(InstallationPrefix)" \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo
 
 override_dh_auto_build:
 	# In case we're installing to a non-standard location, look for a setup.sh
@@ -59,4 +60,7 @@ override_dh_auto_install:
 	# in the install tree that was dropped by catkin, and source it.  It will
 	# set things like CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
-	dh_auto_install
+	dh_auto_install --destdir=$(CURDIR)/debian/@(Package)
+
+override_dh_strip:
+	dh_strip --dbg-package=@(Package)-dbg


### PR DESCRIPTION
This changeset makes bloom generate build files that create a debug symbols
debian package for all ROS packages. As discussed in pull request #32 a future
to-do is to enable building of debug symbols only for ROS packages that have
binary content.
