### PR TITLE
add building of debian platforms to the default actions

### DIFF
--- a/bloom/config.py
+++ b/bloom/config.py
@@ -200,7 +200,9 @@ DEFAULT_TEMPLATE = {
         'git-bloom-generate -y rosrelease :{ros_distro}'
         ' --source upstream -i :{release_inc}',
         'git-bloom-generate -y rosdebian --prefix release/:{ros_distro}'
-        ' :{ros_distro} -i :{release_inc}',
+        ' :{ros_distro} -i :{release_inc} --os-name ubuntu',
+        'git-bloom-generate -y rosdebian --prefix release/:{ros_distro}'
+        ' :{ros_distro} -i :{release_inc} --os-name debian --os-not-required',
         'git-bloom-generate -y rosrpm --prefix release/:{ros_distro}'
         ' :{ros_distro} -i :{release_inc}'
     ]

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -525,6 +525,9 @@ class DebianGenerator(BloomGenerator):
             help="overrides the default installation prefix (/usr)")
         add('--os-name', default='ubuntu',
             help="overrides os_name, set to 'ubuntu' by default")
+        add('--os-not-required', default=False, action="store_true",
+            help="Do not error if this os is not in the platforms "
+                 "list for rosdistro")
 
     def handle_arguments(self, args):
         self.interactive = args.interactive
@@ -535,6 +538,11 @@ class DebianGenerator(BloomGenerator):
             index = rosdistro.get_index(rosdistro.get_index_url())
             distribution_file = rosdistro.get_distribution_file(index, self.rosdistro)
             if self.os_name not in distribution_file.release_platforms:
+                if args.os_not_required:
+                    warning("No platforms defined for os '{0}' in release file for the "
+                            "'{1}' distro. This os was not required; continuing without error."
+                            .format(self.os_name, self.rosdistro))
+                    sys.exit(0)
                 error("No platforms defined for os '{0}' in release file for the '{1}' distro."
                       .format(self.os_name, self.rosdistro), exit=True)
             self.distros = distribution_file.release_platforms[self.os_name]


### PR DESCRIPTION
They will fail gracefully for the older rosdistros which do not have debian platform targets.

As we discussed with @wjwwood [from notes](https://github.com/ros/rosdistro/pull/10621#issuecomment-192541582)

I'd like to parameterize the default actions template on the rosdistro, but that is a much more effort. It will work for now but we will reencounter this any time we add or remove a supported platform. And this will cause indigo and jade instances of bloom to recommend updating the tracks even though they don't need it. 

I've tested this with a Kinetic gbp and it generates the debian targets. And on an indigo track it updates the track and skips the debian targets. 