### PR TITLE
use safe_dump for writing tracks to avoid unicode tags

### DIFF
--- a/bloom/config.py
+++ b/bloom/config.py
@@ -242,7 +242,7 @@ def write_tracks_dict_raw(tracks_dict, cmt_msg=None, directory=None):
     cmt_msg = cmt_msg if cmt_msg is not None else 'Modified tracks.yaml'
     with inbranch(BLOOM_CONFIG_BRANCH):
         with open('tracks.yaml', 'w') as f:
-            f.write(yaml.dump(tracks_dict, indent=2, default_flow_style=False))
+            f.write(yaml.safe_dump(tracks_dict, indent=2, default_flow_style=False))
         execute_command('git add tracks.yaml', cwd=directory)
         execute_command('git commit --allow-empty -m "{0}"'.format(cmt_msg),
                         cwd=directory)


### PR DESCRIPTION
See: https://github.com/ros-infrastructure/bloom/pull/380#issuecomment-192552658

This is a diff of me testing it on my fork of `rviz-release`: https://github.com/wjwwood/rviz-release/commit/e86f9e27756b48dea5a5f96040ce3d5ec54a4259