### PR TITLE
format_description to support unicode

### DIFF
--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -218,7 +218,7 @@ def format_description(value):
 
     https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Description
     """
-    value = debianize_string(value)
+    value = debianize_string(value.encode('ascii', 'replace'))
     # NOTE: bit naive, only works for 'properly formatted' pkg descriptions (ie:
     #       'Text. Text'). Extra space to avoid splitting on arbitrary sequences
     #       of characters broken up by dots (version nrs fi).


### PR DESCRIPTION
we had \beta (\u03b2) string in our package.description and that fails  on bloom-release as follows;
```
Traceback (most recent call last):
  File "/usr/bin/bloom-generate", line 9, in <module>
    load_entry_point('bloom==0.5.21', 'console_scripts', 'bloom-generate')()
  File "/usr/lib/python2.7/dist-packages/bloom/commands/generate.py", line 87, in main
    sys.exit(args.func(args) or 0)
  File "/usr/lib/python2.7/dist-packages/bloom/generators/rosdebian.py", line 123, in main
    debian_main(args, get_subs)
  File "/usr/lib/python2.7/dist-packages/bloom/generators/debian/generate_cmd.py", line 142, in main
    error(type(exc).__name__ + ": " + str(exc), exit=True)
  File "/usr/lib/python2.7/dist-packages/bloom/logging.py", line 285, in error
    sys.exit(msg)
SystemExit: UnicodeEncodeError: 'ascii' codec can't encode character u'\u03b2' in position 65: ordinal not in range(128)

>>> 
```