### PR TITLE
Make it clearer that fedora can be skipped

### DIFF
--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -539,7 +539,8 @@ class RpmGenerator(BloomGenerator):
 
         while not self._check_all_keys_are_valid(peer_packages):
             error("Some of the dependencies for packages in this repository could not be resolved by rosdep.")
-            error("You can try to address the issues which appear above and try again if you wish.")
+            error("You can try to address the issues which appear above and try again if you wish, "
+                  "or continue without releasing into RPM-based distributions (e.g. Fedora 24).")
             try:
                 if not maybe_continue(msg="Would you like to try again?"):
                     error("User aborted after rosdep keys were not resolved.")


### PR DESCRIPTION
releasing moveit just now, we were confused in bloom thinking we couldn't continue since ``libfcl-dev`` is not available in Fedora:

```
Failed to resolve libfcl-dev on fedora:23 with: Error running generator: Failed to resolve rosdep key 'libfcl-dev', aborting.
libfcl-dev is depended on by these packages: ['moveit_core']
<== Failed
Could not resolve rosdep key 'libfcl-dev' for distro '24':
No definition of [libfcl-dev] for OS [fedora]
	rosdep key : libfcl-dev
	OS name    : fedora
	OS version : 24
	Data: arch:
- fcl
debian:
- libfcl-0.5-dev
ubuntu:
- libfcl-0.5-dev

Failed to resolve libfcl-dev on fedora:24 with: Error running generator: Failed to resolve rosdep key 'libfcl-dev', aborting.
libfcl-dev is depended on by these packages: ['moveit_core']
<== Failed
Some of the dependencies for packages in this repository could not be resolved by rosdep.
You can try to address the issues which appear above and try again if you wish.
Would you like to try again? [Y/n]? n
User aborted after rosdep keys were not resolved.
<== The following generator action reported that it is missing one or more
    rosdep keys, but that the key exists in other platforms:
'['/usr/bin/git-bloom-generate', '-y', 'rosrpm', '--prefix', 'release/kinetic', 'kinetic', '-i', '2']'

If you are absolutely sure that this key is unavailable for the platform in
question, the generator can be skipped and you can proceed with the release.
Skip generator action and continue with release [y/N]? y

Action skipped, continuing with release.
```

Talking to @wjwwood he clarified that saying "n" to try again would still allow moveit to be released, skipping Fedora. This clarifies that hopefully.