### PR TITLE
Fix PR fail to forked rosdistro repository

### DIFF
--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -765,7 +765,7 @@ def open_pull_request(track, repository, distro, interactive, override_release_r
     # Check if the github user and the base org are the same
     if gh.username == base_org:
         # If it is, then a fork is not necessary
-        head_repo = base_repo
+        head_repo = gh.get_repo(base_org, base_repo)
     else:
         info(fmt("@{bf}@!==> @|@!Checking on GitHub for a fork to make the pull request from..."))
         # It is not, so a fork will be required


### PR DESCRIPTION
This pull request fixes a crash when bloom-release tries to issue a PR to a forked rosdistro repository which belongs to the user:

```
Would you like to add documentation information for this repository? [Y/n]? n
Would you like to add source information for this repository? [Y/n]? n
Would you like to add a maintenance status for this repository? [Y/n]? n
Unified diff for the ROS distro file located at '/tmp/tmp_CLz5b/catkin-0.7.4-9.patch':
--- 93c8ea127b9356f887282b0b7353edd138528024/minimalist/distribution.yaml
+++ 93c8ea127b9356f887282b0b7353edd138528024/minimalist/distribution.yaml
@@ -19,7 +19,7 @@
       tags:
         release: release/minimalist/{package}/{version}
       url: https://github.com/gdlg/catkin-release.git
-      version: 0.7.4-6
+      version: 0.7.4-9
   cmake_modules:
     release:
       tags:
Traceback (most recent call last):
  File "/home/greg/bloom-prefix/lib/python2.7/site-packages/bloom-0.5.22-py2.7.egg/bloom/commands/release.py", line 1230, in perform_release
    track, repository, distro, interactive, override_release_repository_url
  File "/home/greg/bloom-prefix/lib/python2.7/site-packages/bloom-0.5.22-py2.7.egg/bloom/commands/release.py", line 798, in open_pull_request
    head_repo = head_repo.get('name', '')
AttributeError: 'unicode' object has no attribute 'get'

Failed to open pull request: AttributeError - 'unicode' object has no attribute 'get'

```
