### PR TITLE
add auto-commit for quilt builds

### DIFF
--- a/bloom/generators/debian/templates/source/options.em
+++ b/bloom/generators/debian/templates/source/options.em
@@ -1,0 +1,6 @@
+@[if format and format == 'quilt']@
+# Automatically add upstream changes to the quilt overlay.
+# http://manpages.ubuntu.com/manpages/trusty/man1/dpkg-source.1.html
+# This supports reusing the orig.tar.gz for debian increments.
+auto-commit
+@[end if]


### PR DESCRIPTION
This is a replacement for: https://github.com/ros-infrastructure/ros_buildfarm/pull/395 which is more cross platform.
e.g: https://github.com/ros-infrastructure/ros_buildfarm/pull/397 and https://github.com/ros-infrastructure/ros_buildfarm/pull/398

I ran a test release and the results ended up here: https://github.com/tfoote/test-gbp/blob/debian/kinetic/jessie/tf2_ros/debian/source/options