### PR TITLE
update prompted distro list

### DIFF
--- a/bloom/util.py
+++ b/bloom/util.py
@@ -263,9 +263,9 @@ _quiet = False
 _disable_git_clone = False
 _disable_git_clone_quiet = False
 _distro_list_prompt = [
-    'hydro',
     'indigo',
-    'jade',
+    'kinetic',
+    'lunar',
 ]
 
 


### PR DESCRIPTION
I don't know if there is a way to efficiently get the list of active distro that doesn't imply getting + parsing the rosdistro index file. So this temporary solution updates the prompted list of distributions to match the active ros distros as of May 2017