### PR TITLE
Add strict versions to shlibs

### DIFF
--- a/bloom/generators/debian/templates/rules.em
+++ b/bloom/generators/debian/templates/rules.em
@@ -47,6 +47,13 @@ override_dh_auto_test:
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
 	dh_auto_test || true
 
+override_dh_makeshlibs:
+	# Add strict dependency on the soversion, because the name of the
+	# library package does not contain it.
+	dh_makeshlibs -V
+	sed -i 's/>//' debian/*/DEBIAN/shlibs
+
+
 override_dh_shlibdeps:
 	# In case we're installing to a non-standard location, look for a setup.sh
 	# in the install tree that was dropped by catkin, and source it.  It will


### PR DESCRIPTION
bloom doesn't create separate library packages according to the Debian
policy naming scheme. As we allow ABI breakage in the release (see
Moveit), this results in too lax dependencies for example:

Depends: ros-kinetic-moveit-core

instead of (for example)

Depends: ros-kinetic-moveit-core (= 0.9.6)

Resulting in a library not found when the library name changes.

This adds strict dependencies for all packages containing shlibs.

More discussion: https://github.com/ros-planning/moveit/issues/497