### PR TITLE
Handle utf-8 in more cases.

### DIFF
--- a/bloom/commands/git/import_upstream.py
+++ b/bloom/commands/git/import_upstream.py
@@ -35,6 +35,7 @@ from __future__ import print_function
 import argparse
 import os
 import shutil
+import sys
 import tarfile
 import tempfile
 
@@ -207,10 +208,10 @@ def handle_tree(tree, directory, root_path, version):
             with open(rel_path, 'wb') as f:
                 # Python 2 will treat this as an ascii string but
                 # Python 3 will not re-decode a utf-8 string.
-                try:
-                    file_data = file_data.encode('utf-8')
-                except UnicodeDecodeError:
+                if sys.version_info.major == 2:
                     file_data = file_data.decode('utf-8').encode('utf-8')
+                else:
+                    file_data = file_data.encode('utf-8')
                 f.write(file_data)
             # Add it with git
             execute_command('git add {0}'.format(rel_path), shell=True)

--- a/bloom/commands/git/import_upstream.py
+++ b/bloom/commands/git/import_upstream.py
@@ -38,7 +38,6 @@ import shutil
 import tarfile
 import tempfile
 
-from io import open
 from pkg_resources import parse_version
 
 try:

--- a/bloom/commands/git/import_upstream.py
+++ b/bloom/commands/git/import_upstream.py
@@ -38,6 +38,7 @@ import shutil
 import tarfile
 import tempfile
 
+from io import open
 from pkg_resources import parse_version
 
 try:
@@ -205,6 +206,12 @@ def handle_tree(tree, directory, root_path, version):
                 file_data = show(BLOOM_CONFIG_BRANCH, os.path.join(root_path, rel_path))
             # Write file
             with open(rel_path, 'wb') as f:
+                # Python 2 will treat this as an ascii string but
+                # Python 3 will not re-decode a utf-8 string.
+                try:
+                    file_data = file_data.encode('utf-8')
+                except UnicodeDecodeError:
+                    file_data = file_data.decode('utf-8').encode('utf-8')
                 f.write(file_data)
             # Add it with git
             execute_command('git add {0}'.format(rel_path), shell=True)

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -34,6 +34,7 @@ from __future__ import print_function
 
 import collections
 import datetime
+import io
 import json
 import os
 import pkg_resources
@@ -143,8 +144,11 @@ def __place_template_folder(group, src, dst, gbp=False):
             if os.path.exists(template_dst):
                 debug("Removing existing file '{0}'".format(template_dst))
                 os.remove(template_dst)
-            with open(template_dst, 'w') as f:
+            with io.open(template_dst, 'w', encoding='utf-8') as f:
                 if not isinstance(template, str):
+                    template = template.decode('utf-8')
+                # Python 2 API needs a `unicode` not a utf-8 string.
+                elif sys.version_info.major == 2:
                     template = template.decode('utf-8')
                 f.write(template)
             shutil.copystat(template_abs_path, template_dst)
@@ -434,7 +438,9 @@ def __process_template_folder(path, subs):
             os.path.relpath(template_path)))
         result = em.expand(template, **subs)
         # Write the result
-        with open(template_path, 'w') as f:
+        with io.open(template_path, 'w', encoding='utf-8') as f:
+            if sys.version_info.major == 2:
+                result = result.decode('utf-8')
             f.write(result)
         # Copy the permissions
         shutil.copymode(item, template_path)


### PR DESCRIPTION
![encodings](https://user-images.githubusercontent.com/358882/29636168-9bfaf184-881d-11e7-93f3-ac00ec834618.png)


https://github.com/ros-infrastructure/bloom/commit/1f164c156bf1e3b8b4ae1ea053a16c74ade066c1 is focused on git-bloom-import-upstream and https://github.com/ros-infrastructure/bloom/commit/442b4f8a2f49f969d10feaae18182529f1cae31e contains fixes for the Debian generator. Both are tested with python versions
- 2.7.12
- 3.5.2

The test source repository was https://github.com/eProsima/Fast-RTPS and release repository https://github.com/ros2-gbp/fastrtps-release.

If @wjwwood or @mikaelarguedas knows of any ROS kinetic or lunar packages that have utf-8 characters in the upstream or patched in package.xml template I would love to test this explicitly against them too.

I'm pretty sure the way I'm handling some of the py2/3 encoding cases could be improved upon and standardized throughout bloom, but since search-able documentation and Stack Overflow posts aren't in complete agreement about the best way to keep strings compatible between py2 and py3 I may as well just do _something_ and then iterate on it with input from the ROS team. Feel free to make suggestions about alternative implementations.