### PR TITLE
Add support for ROS 2 build types.

### DIFF
--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -543,8 +543,9 @@ def set_debhelper_options(data, package):
             'toplevel': '--buildsystem=pybuild --with python3',
             'depends': '${python3:Depends}',
             'exportvars': [('PYBUILD_INSTALL_ARGS',
-                           '--prefix="{0}" --install-lib="{0}/lib/{{interpreter}}/site-packages"'
-                            .format(data['InstallationPrefix']))],
+                           '--prefix="{0}" --install-lib="$base/lib/{{interpreter}}/site-packages" '
+                           '--install-scripts="$base/bin"'
+                           .format(data['InstallationPrefix']))],
         },
         'cmake': {
             'toplevel': '--buildsystem=cmake',

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -513,20 +513,22 @@ def debianize_string(value):
 def sanitize_package_name(name):
     return name.replace('_', '-')
 
+
 def set_debhelper_options(data, package):
     debhelper_options = {
-            'ament_cmake': {
-                'toplevel': '--buildsystem=cmake',
-                'autoconfigure': '-- -DCMAKE_INSTALL_PREFIX="{0}" -DAMENT_PREFIX_PATH="{0}"'.format(data['InstallationPrefix'])
-                },
-            'ament_python': {
-                'toplevel': '--buildsystem=pybuild --with python3',
-                },
-            'cmake': {
-                'toplevel': '--buildsystem=cmake',
-                'autoconfigure': '-- -DCMAKE_INSTALL_PREFIX="{0}"'.format(data['InstallationPrefix'])
-                },
-            }
+        'ament_cmake': {
+            'toplevel': '--buildsystem=cmake',
+            'autoconfigure': '-- -DCMAKE_INSTALL_PREFIX="{0}" -DAMENT_PREFIX_PATH="{0}"'
+            .format(data['InstallationPrefix'])
+        },
+        'ament_python': {
+            'toplevel': '--buildsystem=pybuild --with python3',
+        },
+        'cmake': {
+            'toplevel': '--buildsystem=cmake',
+            'autoconfigure': '-- -DCMAKE_INSTALL_PREFIX="{0}"'.format(data['InstallationPrefix'])
+        },
+    }
     # This inlines changes upcoming in catkin_pkg
     # https://github.com/ros-infrastructure/catkin_pkg/pull/168
     # We can simplify this function when catkin_pkg is released.
@@ -537,7 +539,7 @@ def set_debhelper_options(data, package):
         build_type = build_type[0]
         if build_type not in debhelper_options:
             error('The build type `{build_type}`is not supported by this version of bloom.'
-                    .format(build_type=build_type), exit=True)
+                  .format(build_type=build_type), exit=True)
         data['debhelper_toplevel_options'] = debhelper_options[build_type].get('toplevel', '')
         data['debhelper_autoconfigure_options'] = debhelper_options[build_type].get('autoconfigure', '')
     else:

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -86,7 +86,6 @@ from bloom.util import maybe_continue
 try:
     from catkin_pkg.changelog import get_changelog_from_path
     from catkin_pkg.changelog import CHANGELOG_FILENAME
-    from catkin_pkg.package import Dependency
 except ImportError as err:
     debug(traceback.format_exc())
     error("catkin_pkg was not detected, please install it.", exit=True)

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -308,6 +308,7 @@ def generate_substitutions_from_package(
     # Resolve dependencies
     depends = package.run_depends + package.buildtool_export_depends
     build_depends = package.build_depends + package.buildtool_depends + package.test_depends
+
     unresolved_keys = depends + build_depends + package.replaces + package.conflicts
     # The installer key is not considered here, but it is checked when the keys are checked before this
     resolved_deps = resolve_dependencies(unresolved_keys, os_name,
@@ -326,6 +327,8 @@ def generate_substitutions_from_package(
     data['Conflicts'] = sorted(
         set(format_depends(package.conflicts, resolved_deps))
     )
+
+    set_debhelper_options(data, package)
     # Set the distribution
     data['Distribution'] = os_version
     # Use the time stamp to set the date strings
@@ -509,6 +512,32 @@ def debianize_string(value):
 
 def sanitize_package_name(name):
     return name.replace('_', '-')
+
+def set_debhelper_options(data, package):
+    debhelper_options = {
+            'ament_cmake': {
+                'toplevel': '--buildsystem=cmake',
+                'autoconfigure': '-- -DCMAKE_INSTALL_PREFIX="{0}" -DAMENT_PREFIX_PATH="{0}"'.format(data['InstallationPrefix'])
+                },
+            'ament_python': {
+                'toplevel': '--buildsystem=pybuild --with python3',
+                },
+            }
+    # This inlines changes upcoming in catkin_pkg
+    # https://github.com/ros-infrastructure/catkin_pkg/pull/168
+    # We can simplify this function when catkin_pkg is released.
+    build_type = [e.content for e in package.exports if e.tagname == 'build_type']
+    if build_type is None:
+        error('ROS 2 packages currently need an explicit build type.', exit=True)
+    if len(build_type) == 1:
+        build_type = build_type[0]
+        if build_type not in debhelper_options:
+            error('The build type `{build_type}`is not supported by this version of bloom.'
+                    .format(build_type=build_type), exit=True)
+        data['debhelper_toplevel_options'] = debhelper_options[build_type].get('toplevel', '')
+        data['debhelper_autoconfigure_options'] = debhelper_options[build_type].get('autoconfigure', '')
+    else:
+        error('Only one build_type can be supported.', exit=True)
 
 
 class DebianGenerator(BloomGenerator):

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -543,9 +543,10 @@ def set_debhelper_options(data, package):
             'toplevel': '--buildsystem=pybuild --with python3',
             'depends': '${python3:Depends}',
             'exportvars': [('PYBUILD_INSTALL_ARGS',
-                           '--prefix="{0}" --install-lib="\$$base/lib/{{interpreter}}/site-packages" '
-                           '--install-scripts="\$$base/bin"'
-                           .format(data['InstallationPrefix']))],
+                           '--prefix "{0}" '
+                            '--install-lib "\$$base/lib/{{interpreter}}/site-packages" '
+                            '--install-scripts "\$$base/bin"'
+                            .format(data['InstallationPrefix']))],
         },
         'cmake': {
             'toplevel': '--buildsystem=cmake',

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -543,8 +543,8 @@ def set_debhelper_options(data, package):
             'toplevel': '--buildsystem=pybuild --with python3',
             'depends': '${python3:Depends}',
             'exportvars': [('PYBUILD_INSTALL_ARGS',
-                           '--prefix="{0}" --install-lib="$base/lib/{{interpreter}}/site-packages" '
-                           '--install-scripts="$base/bin"'
+                           '--prefix="{0}" --install-lib="$$base/lib/{{interpreter}}/site-packages" '
+                           '--install-scripts="$$base/bin"'
                            .format(data['InstallationPrefix']))],
         },
         'cmake': {

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -543,8 +543,8 @@ def set_debhelper_options(data, package):
             'toplevel': '--buildsystem=pybuild --with python3',
             'depends': '${python3:Depends}',
             'exportvars': [('PYBUILD_INSTALL_ARGS',
-                           '--prefix="{0}" --install-lib="$$base/lib/{{interpreter}}/site-packages" '
-                           '--install-scripts="$$base/bin"'
+                           '--prefix="{0}" --install-lib="\$$base/lib/{{interpreter}}/site-packages" '
+                           '--install-scripts="\$$base/bin"'
                            .format(data['InstallationPrefix']))],
         },
         'cmake': {

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -311,7 +311,6 @@ def generate_substitutions_from_package(
     depends = package.run_depends + package.buildtool_export_depends
     build_depends = package.build_depends + package.buildtool_depends + package.test_depends
 
-
     # XXX inject build type specific dependencies.
     build_type = package.get_build_type()
     if build_type == 'ament_cmake':
@@ -543,11 +542,15 @@ def set_debhelper_options(data, package):
         'ament_python': {
             'toplevel': '--buildsystem=pybuild --with python3',
             'depends': '${python3:Depends}',
+            'exportvars': [('PYBUILD_INSTALL_ARGS',
+                           '--prefix="{0}" --install-lib="{0}/{{interpreter}}/site-packages"'
+                            .format(data['InstallationPrefix']))],
         },
         'cmake': {
             'toplevel': '--buildsystem=cmake',
             'autoconfigure': '-- -DCMAKE_INSTALL_PREFIX="{0}"'.format(data['InstallationPrefix']),
             'depends': '${shlibs:Depends}',
+            'exportvars': [],
         },
     }
 
@@ -558,6 +561,7 @@ def set_debhelper_options(data, package):
     data['debhelper_toplevel_options'] = debhelper_options[build_type].get('toplevel', '')
     data['debhelper_autoconfigure_options'] = debhelper_options[build_type].get('autoconfigure', '')
     data['DebhelperDepends'] = debhelper_options[build_type].get('depends', '')
+    data['exportvars'] = debhelper_options[build_type].get('exportvars', [])
 
 
 class DebianGenerator(BloomGenerator):

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -543,7 +543,7 @@ def set_debhelper_options(data, package):
             'toplevel': '--buildsystem=pybuild --with python3',
             'depends': '${python3:Depends}',
             'exportvars': [('PYBUILD_INSTALL_ARGS',
-                           '--prefix="{0}" --install-lib="{0}/{{interpreter}}/site-packages"'
+                           '--prefix="{0}" --install-lib="{0}/lib/{{interpreter}}/site-packages"'
                             .format(data['InstallationPrefix']))],
         },
         'cmake': {

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -522,6 +522,10 @@ def set_debhelper_options(data, package):
             'ament_python': {
                 'toplevel': '--buildsystem=pybuild --with python3',
                 },
+            'cmake': {
+                'toplevel': '--buildsystem=cmake',
+                'autoconfigure': '-- -DCMAKE_INSTALL_PREFIX="{0}"'.format(data['InstallationPrefix'])
+                },
             }
     # This inlines changes upcoming in catkin_pkg
     # https://github.com/ros-infrastructure/catkin_pkg/pull/168

--- a/bloom/generators/debian/templates/control.em
+++ b/bloom/generators/debian/templates/control.em
@@ -8,7 +8,7 @@ Standards-Version: 3.9.2
 
 Package: @(Package)
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, @(', '.join(Depends))
+Depends: @(DebhelperDepends), ${misc:Depends}, @(', '.join(Depends))
 @[if Conflicts]Conflicts: @(', '.join(Conflicts))@\n@[end if]@
 @[if Replaces]Replaces: @(', '.join(Replaces))@\n@[end if]@
 Description: @(Description)

--- a/bloom/generators/debian/templates/rules.em
+++ b/bloom/generators/debian/templates/rules.em
@@ -18,6 +18,11 @@ export PKG_CONFIG_PATH=@(InstallationPrefix)/lib/pkgconfig
 # 	https://github.com/ros-infrastructure/bloom/issues/327
 export DEB_CXXFLAGS_MAINT_APPEND=-DNDEBUG
 
+# Build type specific exports if any.
+@[for var in exportvars]@
+export @(var[0])=@(var[1])
+@[end for]@
+
 %:
 	dh $@@ -v @(debhelper_toplevel_options)
 

--- a/bloom/generators/debian/templates/rules.em
+++ b/bloom/generators/debian/templates/rules.em
@@ -8,7 +8,6 @@
 
 # Uncomment this to turn on verbose mode.
 export DH_VERBOSE=1
-export DH_OPTIONS=-v --buildsystem=cmake
 # TODO: remove the LDFLAGS override.  It's here to avoid esoteric problems
 # of this sort:
 #  https://code.ros.org/trac/ros/ticket/2977
@@ -20,17 +19,14 @@ export PKG_CONFIG_PATH=@(InstallationPrefix)/lib/pkgconfig
 export DEB_CXXFLAGS_MAINT_APPEND=-DNDEBUG
 
 %:
-	dh  $@@
+	dh $@@ -v @(debhelper_toplevel_options)
 
 override_dh_auto_configure:
 	# In case we're installing to a non-standard location, look for a setup.sh
 	# in the install tree that was dropped by catkin, and source it.  It will
 	# set things like CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
-	dh_auto_configure -- \
-		-DCATKIN_BUILD_BINARY_PACKAGE="1" \
-		-DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" \
-		-DCMAKE_PREFIX_PATH="@(InstallationPrefix)"
+	dh_auto_configure @(debhelper_autoconfigure_options)
 
 override_dh_auto_build:
 	# In case we're installing to a non-standard location, look for a setup.sh

--- a/bloom/generators/debian/templates/rules.em
+++ b/bloom/generators/debian/templates/rules.em
@@ -19,8 +19,8 @@ export PKG_CONFIG_PATH=@(InstallationPrefix)/lib/pkgconfig
 export DEB_CXXFLAGS_MAINT_APPEND=-DNDEBUG
 
 # Build type specific exports if any.
-@[for var in exportvars]@
-export @(var[0])=@(var[1])
+@[for name, value in exportvars.items()]@
+export @(name)=@(value)
 @[end for]@
 
 %:

--- a/bloom/generators/rosdebian.py
+++ b/bloom/generators/rosdebian.py
@@ -87,7 +87,8 @@ class RosDebianGenerator(DebianGenerator):
         )
         subs['Package'] = rosify_package_name(subs['Package'], self.rosdistro)
         # XXX Add workspace package to runtime and buildtime dependencies.
-        # This is a ros2-specific hack that should be factored better into the buildfarm/bloom release process.
+        # This is a ros2-specific hack that should be factored better into the buildfarm/bloom
+        # release process. Also, it's likely to create a circular dependency if we're not careful.
         if package.name not in ['ament_cmake_core', 'ament_package', 'ros_workspace']:
             workspace_pkg_name = rosify_package_name('ros-workspace', self.rosdistro)
             subs['BuildDepends'].append(workspace_pkg_name)

--- a/bloom/generators/rosdebian.py
+++ b/bloom/generators/rosdebian.py
@@ -86,6 +86,11 @@ class RosDebianGenerator(DebianGenerator):
             fallback_resolver=fallback_resolver
         )
         subs['Package'] = rosify_package_name(subs['Package'], self.rosdistro)
+        # Add workspace package to runtime and buildtime dependencies.
+        if package.name not in ['ament_cmake_core', 'ament_package']:
+            workspace_pkg_name = rosify_package_name('ros-workspace', self.rosdistro)
+            subs['BuildDepends'].append(workspace_pkg_name)
+            subs['Depends'].append(workspace_pkg_name)
         return subs
 
     def generate_branching_arguments(self, package, branch):

--- a/bloom/generators/rosdebian.py
+++ b/bloom/generators/rosdebian.py
@@ -86,7 +86,8 @@ class RosDebianGenerator(DebianGenerator):
             fallback_resolver=fallback_resolver
         )
         subs['Package'] = rosify_package_name(subs['Package'], self.rosdistro)
-        # Add workspace package to runtime and buildtime dependencies.
+        # XXX Add workspace package to runtime and buildtime dependencies.
+        # This is a ros2-specific hack that should be factored better into the buildfarm/bloom release process.
         if package.name not in ['ament_cmake_core', 'ament_package']:
             workspace_pkg_name = rosify_package_name('ros-workspace', self.rosdistro)
             subs['BuildDepends'].append(workspace_pkg_name)

--- a/bloom/generators/rosdebian.py
+++ b/bloom/generators/rosdebian.py
@@ -88,7 +88,7 @@ class RosDebianGenerator(DebianGenerator):
         subs['Package'] = rosify_package_name(subs['Package'], self.rosdistro)
         # XXX Add workspace package to runtime and buildtime dependencies.
         # This is a ros2-specific hack that should be factored better into the buildfarm/bloom release process.
-        if package.name not in ['ament_cmake_core', 'ament_package']:
+        if package.name not in ['ament_cmake_core', 'ament_package', 'ros_workspace']:
             workspace_pkg_name = rosify_package_name('ros-workspace', self.rosdistro)
             subs['BuildDepends'].append(workspace_pkg_name)
             subs['Depends'].append(workspace_pkg_name)


### PR DESCRIPTION
This PR is directly based on the work in https://github.com/ros2/bloom.

It adds support for the ROS 2 build types and needed features by replacing explicit template contents with template variables that mostly come from the `set_build_type_options` function.

This is the minimal changeset required to support packaging ROS 2 for Beta 3 and is meant as a foil PR to https://github.com/ros-infrastructure/bloom/pull/435 which contains a reorganization of the debian templates.

There is some work still outstanding if this candidate is to be merged: Critically: I haven't yet re-added support for catkin packages. I also need to add some tests that will cover the ROS 2 packages.