### PR TITLE
Fix python 2/3 import compatibility.

### DIFF
--- a/bloom/github.py
+++ b/bloom/github.py
@@ -42,18 +42,19 @@ import datetime
 import json
 import socket
 
-from urlparse import urlunsplit
-from urllib import urlencode
 
 try:
     # Python2
+    from urllib import urlencode
     from urllib2 import HTTPError
-    from urllib2 import URLError
     from urllib2 import Request, urlopen
+    from urllib2 import URLError
+    from urlparse import urlunsplit
 except ImportError:
     # Python3
     from urllib.error import HTTPError
     from urllib.error import URLError
+    from urllib.parse import urlunsplit
     from urllib.request import Request, urlopen
 
 import bloom


### PR DESCRIPTION
Fixes an import failure preventing `bloom-release --version` (and likely other things) from being run on python 3.

Found when smoke testing bloom 0.6.0.