### PR TITLE
Prepare 0.6.1 release.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+0.6.1 (2017-10-20 13:45:00 -0800)
+---------------------------------
+- Switched to PyPI JSON API for online updates check. `#438 <https://github.com/ros-infrastructure/bloom/pull/438>`_
+- Fixed regression in bloom-generate. `#440 <https://github.com/ros-infrastructure/bloom/pull/440>`_
+- Fixed bloom-release in python3. `#441 <https://github.com/ros-infrastructure/bloom/pull/441>`_
+
 0.6.0 (2017-10-19 10:30:00 -0800)
 ---------------------------------
 - Added artful support to release configuration.

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if sys.version_info[0] == 2 and sys.version_info[1] <= 6:
 
 setup(
     name='bloom',
-    version='0.6.0',
+    version='0.6.1',
     packages=find_packages(exclude=['test']),
     package_data={
         'bloom.generators.debian': [


### PR DESCRIPTION
Updates CHANGELOG and setup.py for 0.6.1.

🚧 When ready, squash all changes into a single commit with message `0.6.1` and rebase or fast-forward directly onto master.

Includes
- #438 
- #440 
- #441 