### PR TITLE
Fix setuptools test.* package pollution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if sys.version_info[0] == 2 and sys.version_info[1] <= 6:
 setup(
     name='bloom',
     version='0.6.1',
-    packages=find_packages(exclude=['test']),
+    packages=find_packages(exclude=['test', 'test.*']),
     package_data={
         'bloom.generators.debian': [
             'bloom/generators/debian/templates/*',


### PR DESCRIPTION
setup.py: find_package(exclude['test']) was not enough to exclude all
of the test packages bloom uses, there are a lot of subpackages (test.*)
that were not being caught and thus were being installed in
site-packages.