### PR TITLE
Fixed python3 bloom-release, json.loads encoding

### DIFF
--- a/bloom/github.py
+++ b/bloom/github.py
@@ -98,6 +98,7 @@ def do_github_post_req(path, data=None, auth=None, site='api.github.com'):
 
     return response
 
+
 def json_loads(resp):
     try:
         charset = resp.headers.getparam('charset')
@@ -106,6 +107,7 @@ def json_loads(resp):
         charset = resp.headers.get_content_charset()
 
     return json.loads(resp.read().decode(charset))
+
 
 class GithubException(Exception):
     def __init__(self, msg, resp=None):

--- a/bloom/github.py
+++ b/bloom/github.py
@@ -100,6 +100,7 @@ def do_github_post_req(path, data=None, auth=None, site='api.github.com'):
 
 
 def json_loads(resp):
+    """Handle parsing json from an HTTP response for both Python 2 and Python 3."""
     try:
         charset = resp.headers.getparam('charset')
         charset = 'utf8' if not charset else charset


### PR DESCRIPTION
json.loads excepts a string, but resp.read() returns a bytes object in
Python3. Added a helper function to try to detect the encoding of the
response, and use that to decode the bytes to str.

Tested this briefly with Python2 to make sure it wasn't broken. Tried to make it compatible.