### PR TITLE
GitHub PR auth prompt fixes

### DIFF
--- a/bloom/github.py
+++ b/bloom/github.py
@@ -92,11 +92,15 @@ def do_github_post_req(path, data=None, auth=None, site='api.github.com'):
     try:
         response = urlopen(request, timeout=120)
     except HTTPError as e:
-        raise GithubException(str(e) + ' (%s)' % url)
+        if e.code in [401]:
+            raise GitHubAuthException(str(e) + ' (%s)' % url)
+        else:
+            raise GithubException(str(e) + ' (%s)' % url)
     except URLError as e:
         raise GithubException(str(e) + ' (%s)' % url)
 
     return response
+
 
 
 class GithubException(Exception):
@@ -108,6 +112,11 @@ class GithubException(Exception):
         super(GithubException, self).__init__(msg)
         if resp:
             self.resp = resp
+
+
+class GitHubAuthException(GithubException):
+    def __init__(self, msg):
+        super(GithubException, self).__init__(msg)
 
 
 class Github(object):

--- a/bloom/github.py
+++ b/bloom/github.py
@@ -102,7 +102,6 @@ def do_github_post_req(path, data=None, auth=None, site='api.github.com'):
     return response
 
 
-
 class GithubException(Exception):
     def __init__(self, msg, resp=None):
         if resp:


### PR DESCRIPTION
This is a proposed fix for #448.

A detailed outline of the code paths is present in that issue.
The error interface appears to have changed since the original code was written.
This adds code to handle the new error interface while preserving the old code.
It's possible this old code is no longer used and can be removed but I wouldn't know how to tell since #448 surfaces for me using both Python 2 and Python 3.