### PR TITLE
0.6.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+0.6.2 (2018-01-08 13:45:00 -0800)
+---------------------------------
+- Removed test.* subpackages from installation. `#444 <https://github.com/ros-infrastructure/bloom/pull/444>`_
+- Prepared for release supporting Ubuntu Bionic Beaver. `#452 <https://github.com/ros-infrastructure/bloom/pull/452>`_
+- Fixed error message when GitHub Multi-Factor auth is enabled. `#451 <https://github.com/ros-infrastructure/bloom/pull/451>`_
+- Added support for ROS 2 Ardent Apalone. `#453 <https://github.com/ros-infrastructure/bloom/pull/453>`_
+- Fixed an HTTP/JSON encoding issue in bloom-release for Python 3. `#445 <https://github.com/ros-infrastructure/bloom/pull/445>`_
+
 0.6.1 (2017-10-20 13:45:00 -0800)
 ---------------------------------
 - Switched to PyPI JSON API for online updates check. `#438 <https://github.com/ros-infrastructure/bloom/pull/438>`_

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if sys.version_info[0] == 2 and sys.version_info[1] <= 6:
 
 setup(
     name='bloom',
-    version='0.6.1',
+    version='0.6.2',
     packages=find_packages(exclude=['test', 'test.*']),
     package_data={
         'bloom.generators.debian': [


### PR DESCRIPTION
This commit should be squash-merged or otherwise fast-forwarded onto master.

Excerpts from the changelog below:

- Removed test.* subpackages from installation. #444
- Prepared for release supporting Ubuntu Bionic Beaver. #452
- Fixed error message when GitHub Multi-Factor auth is enabled. #451
- Added support for ROS 2 Ardent Apalone. #453
- Fixed an HTTP/JSON encoding issue in bloom-release for Python 3. #445


I'd like to shoutout and give thanks this release to @gemarcano who contributed #444 and #445.