### PR TITLE
RELEASE REPO BASE env var

### DIFF
--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -44,6 +44,7 @@ import json
 import os
 import pkg_resources
 import platform
+import requests
 import shutil
 import subprocess
 import sys
@@ -296,6 +297,16 @@ def validate_github_url(url, url_type):
     return True
 
 
+def infer_release_repo_from_env(repository):
+    base = os.environ.get('BLOOM_RELEASE_REPO_BASE', None)
+    if base is None:
+        return None
+    url = base + repository + '-release.git'
+    r = requests.get(url)
+    if r.status_code == requests.codes.ok:
+        return url
+
+
 def get_repo_uri(repository, distro):
     url = None
     # Fetch the distro file
@@ -309,6 +320,8 @@ def get_repo_uri(repository, distro):
         matches = difflib.get_close_matches(repository, distribution_file.repositories)
         if matches:
             info(fmt("@{yf}Did you mean one of these: '" + "', '".join([m for m in matches]) + "'?"))
+    if url is None:
+        url = infer_release_repo_from_env(repository)
     if url is None:
         info("Could not determine release repository url for repository '{0}' of distro '{1}'"
              .format(repository, distro))

--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -298,6 +298,11 @@ def validate_github_url(url, url_type):
 
 
 def infer_release_repo_from_env(repository):
+    """
+        If the environment var BLOOM_RELEASE_REPO_BASE exists, and
+        BLOOM_RELEASE_REPO_BASE + repository + '-release.git' exists online,
+        then this function will return the newly composed url
+    """
     base = os.environ.get('BLOOM_RELEASE_REPO_BASE', None)
     if base is None:
         return None


### PR DESCRIPTION
 * Enables the use of a new environment variable `BLOOM_RELEASE_REPO_BASE`. 
   * This can be used instead of manually inputting the release repo url. 
   * If the environment var exists, and `BLOOM_RELEASE_REPO_BASE` + repository + '-release.git' exists as a repository, then it will use that as the release repo.
   * For example, all my release repos are over at `https://github.com/wu-robotics/` so if I set that as my environment variable, I can create a `bloom-example-release` repo there, and then if I try to `bloom-release` a package called `bloom-example`, it will automagically use that as my release repo. 