### PR TITLE
don't error if git repo has submodules

### DIFF
--- a/bloom/commands/export_upstream.py
+++ b/bloom/commands/export_upstream.py
@@ -51,7 +51,6 @@ from bloom.logging import warning
 
 from bloom.git import branch_exists
 from bloom.git import get_root
-from bloom.git import has_submodules
 from bloom.git import tag_exists
 
 from bloom.util import add_global_arguments

--- a/bloom/commands/export_upstream.py
+++ b/bloom/commands/export_upstream.py
@@ -121,14 +121,6 @@ def export_upstream(uri, tag, vcs_type, output_dir, show_uri, name):
                 error("Failed to clone repository at '{0}'".format(uri) +
                       (" to reference '{0}'.".format(tag) if tag else '.'),
                       exit=True)
-        if get_root() is not None and has_submodules(upstream_repo.get_path()):
-            error("""\
-bloom does not support exporting git repositories with submodules, see:
-
-- https://github.com/ros-infrastructure/bloom/issues/202
-- https://github.com/ros-infrastructure/bloom/issues/217
-- https://github.com/vcstools/vcstools/issues/84
-""", exit=True)
         tarball_prefix = '{0}-{1}'.format(name, tag) if tag else name
         tarball_path = os.path.join(output_dir, tarball_prefix)
         full_tarball_path = tarball_path + '.tar.gz'

--- a/bloom/git.py
+++ b/bloom/git.py
@@ -708,26 +708,6 @@ def get_last_tag_by_date(directory=None):
     return output[-1]
 
 
-def has_submodules(directory=None):
-    """
-    Returns True if the git repository at this directory has submodules
-
-    :param directory: directory to check for submodules in
-    :returns: True if there are submodules, False otherwise
-
-    :raises: RuntimeError if directory is not a git repository
-    """
-    root = get_root(directory)
-    checked_dir = directory or os.getcwd()
-    if root is None:
-        raise RuntimeError("Directory '{0}' is not in a git repository.".format(checked_dir))
-    cmd = "git submodule status"
-    output = check_output(cmd, shell=True, cwd=root, stderr=PIPE)
-    if not output.strip():
-        return False
-    return True
-
-
 def get_remotes(directory=None):
     """
     Returns a list of remote names.


### PR DESCRIPTION
although it seems this error was not even triggered before...
In any case releasing an upstream repo with submodules works with
https://github.com/vcstools/vcstools/pull/130

With the vcstools fix, we should be able to close https://github.com/ros-infrastructure/bloom/issues/217
At least it worked for me...