### PR TITLE
Test on Python 3.4 and 3.6 because 3.3 is EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
+  - "3.4"
+  - "3.6"
 # command to install dependencies
 install:
   - pip install PyYAML argparse rosdep vcstools catkin-pkg python-dateutil setuptools


### PR DESCRIPTION
Current versions of Python: https://devguide.python.org/#branchstatus

Python 3.3 reached its end of life last year.