### PR TITLE
Remove unexamined dependency on requests.

### DIFF
--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -44,7 +44,6 @@ import json
 import os
 import pkg_resources
 import platform
-import requests
 import shutil
 import subprocess
 import sys
@@ -57,8 +56,11 @@ from pkg_resources import parse_version
 
 # python2/3 compatibility
 try:
+    from urllib.error import HTTPError, URLError
     from urllib.parse import urlparse
+    from urllib.request import Request, urlopen
 except ImportError:
+    from urllib2 import HTTPError, Request, URLError, urlopen
     from urlparse import urlparse
 
 import bloom
@@ -307,9 +309,13 @@ def infer_release_repo_from_env(repository):
     if base is None:
         return None
     url = base + repository + '-release.git'
-    r = requests.get(url)
-    if r.status_code == requests.codes.ok:
-        return url
+    try:
+        urlopen(Request(url))
+    except URLError:
+        return None
+    except HTTPError:
+        return None
+    return url
 
 
 def get_repo_uri(repository, distro):

--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -301,9 +301,11 @@ def validate_github_url(url, url_type):
 
 def infer_release_repo_from_env(repository):
     """
-        If the environment var BLOOM_RELEASE_REPO_BASE exists, and
-        BLOOM_RELEASE_REPO_BASE + repository + '-release.git' exists online,
-        then this function will return the newly composed url
+    Generate a release repo url from a hint variable.
+
+    If the environment var BLOOM_RELEASE_REPO_BASE exists, and
+    BLOOM_RELEASE_REPO_BASE + repository + '-release.git' exists online, then
+    this function will return the newly composed url
     """
     base = os.environ.get('BLOOM_RELEASE_REPO_BASE', None)
     if base is None:


### PR DESCRIPTION
I missed remarking upon the dependency introduction when reviewing #460. This replaces the use of requests with standard library http handling.

Requests is a phenomenal library and I can definitely see bloom adopting its use in the future but I'd rather make that decision intentionally rather than in a minor release.

Fixes #467.
