### PR TITLE
0.6.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+0.6.4 (2018-03-20 13:15:00 -0800)
+---------------------------------
+- Fixed use of non-dependency library. `#468 <https://github.com/ros-infrastructure/bloom/pull/468>`_
+
 0.6.3 (2018-03-09 11:05:00 -0800)
 ---------------------------------
 - Released for Debian buster. `#457 <https://github.com/ros-infrastructure/bloom/pull/457>`_

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if sys.version_info[0] == 2 and sys.version_info[1] <= 6:
 
 setup(
     name='bloom',
-    version='0.6.3',
+    version='0.6.4',
     packages=find_packages(exclude=['test', 'test.*']),
     package_data={
         'bloom.generators.debian': [


### PR DESCRIPTION
Rendered changelog link: https://github.com/ros-infrastructure/bloom/blob/f0f7f52f7c586cd49cbcd0059b75c922e0c6a8ea/CHANGELOG.rst

Like other release prep PRs, this should be merged via fast-forward onto master.