### PR TITLE
Upstream Tag

### DIFF
--- a/bloom/commands/git/release.py
+++ b/bloom/commands/git/release.py
@@ -304,6 +304,9 @@ def execute_track(track, track_dict, release_inc, pretend=True, debug=False, fas
         tracks_dict = get_tracks_dict_raw()
         tracks_dict['tracks'][track]['release_inc'] = settings['release_inc']
         tracks_dict['tracks'][track]['last_version'] = settings['version']
+        # if release tag is set to ask and a custom value is used
+        if settings['version'] != settings['release_tag']:
+            tracks_dict['tracks'][track]['last_release'] = settings['release_tag']
         write_tracks_dict_raw(tracks_dict,
                               'Updating release inc to: ' + str(settings['release_inc']))
 

--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -454,6 +454,8 @@ def generate_ros_distro_diff(track, repository, distro, override_release_reposit
         repo['tags'.encode('utf-8')] = {}
     repo['tags']['release'.encode('utf-8')] = generate_release_tag(distro)
     repo['version'.encode('utf-8')] = version
+    if 'last_release' in track_dict:
+        repo['upstream_tag'.encode('utf-8')] = track_dict['last_release']
     if 'packages' not in repo:
         repo['packages'.encode('utf-8')] = []
     for path, pkg in packages.items():


### PR DESCRIPTION
If `:{ask}` is specified for the release tag, the upstream tag is not written into the release repository, making it quite difficult to figure out what tag was used. This PR ensures that it is written into `tracks.yaml`. 