### PR TITLE
Revert "Add bouncy to the list of rosdistros to get the workspace shim."

### DIFF
--- a/bloom/generators/rosdebian.py
+++ b/bloom/generators/rosdebian.py
@@ -88,7 +88,7 @@ class RosDebianGenerator(DebianGenerator):
         subs['Package'] = rosify_package_name(subs['Package'], self.rosdistro)
 
         # XXX Add workspace package to runtime and buildtime dependencies for ROS 2 only.
-        if self.rosdistro in ['r2b2', 'r2b3', 'ardent', 'bouncy'] and \
+        if self.rosdistro in ['r2b2', 'r2b3', 'ardent'] and \
                 package.name not in ['ament_cmake_core', 'ament_package', 'ros_workspace']:
                     workspace_pkg_name = rosify_package_name('ros-workspace', self.rosdistro)
                     subs['BuildDepends'].append(workspace_pkg_name)


### PR DESCRIPTION
This reverts #462.

For Bouncy we won't use the `ros_workspace` repository but let the `ament_cmake_core` package provide the setup files instead using [this option](https://github.com/ament/ament_cmake/blob/4e46886895a9f97c0ef82c4fedacd13dcb010aac/ament_cmake_core/ament_cmake_environment-extras.cmake#L17-L18).