### PR TITLE
Reference the LICENSE.txt from the stdeb.cfg

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,5 +3,6 @@ Depends: python-yaml, python-empy, python-argparse, python-rosdep (>= 0.10.25), 
 Depends3: python3-yaml, python3-empy, python3-rosdep (>= 0.10.25), python3-rosdistro (>= 0.4.0), python3-vcstools (>= 0.1.22), python3-setuptools, python3-catkin-pkg (>= 0.3.8)
 Conflicts: python3-bloom
 Conflicts3: python-bloom
+Copyright-File: LICENSE.txt
 Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty artful bionic wheezy jessie stretch buster
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
stdeb will install it in the debian way when referenced here.