### PR TITLE
0.6.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+0.6.5 (2018-06-25 07:00:00 -0800)
+---------------------------------
+- Added injection of vendor typesupport packages into build deps for ROS 2. `#475 <https://github.com/ros-infrastructure/bloom/pull/475>`_
+- Updated message wording. `#471 <https://github.com/ros-infrastructure/bloom/pull/471>`_
+- Updated tested python versions. `#466 <https://github.com/ros-infrastructure/bloom/pull/466>`_
+
 0.6.4 (2018-03-20 13:15:00 -0800)
 ---------------------------------
 - Fixed use of non-dependency library. `#468 <https://github.com/ros-infrastructure/bloom/pull/468>`_

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if sys.version_info[0] == 2 and sys.version_info[1] <= 6:
 
 setup(
     name='bloom',
-    version='0.6.4',
+    version='0.6.5',
     packages=find_packages(exclude=['test', 'test.*']),
     package_data={
         'bloom.generators.debian': [


### PR DESCRIPTION
This commit should be fast-forwarded onto master. The pull request is opened for visibility. In order to get #475 released for Bouncy, I'm going to take approval of #475 as approval to release.

This release also includes #471 and #466 
Many thanks to their authors for the contributions.