### PR TITLE
Update copyright info and date.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,7 @@
 Software License Agreement (BSD License)
 
 Copyright (c) 2013, Willow Garage, Inc.
+Copyright (c) 2013-2018, Open Source Robotics Foundation, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
I'm no pro at license structure but it seems to be convention in our other projects to update the copyright year with the most recent year changes have been made.

Since we're going to start distributing the license in deb packages (#470) it made sense to me to make sure that license info was up to date.

Obligatory: I am not a lawyer