### PR TITLE
Reorder commands (toward Gitlab compatibility)

### DIFF
--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -881,7 +881,8 @@ Increasing version of package(s) in repository `{repository}` to `{version}`:
                 check_call(cmd, shell=True)
             # Use the oauth token to clone
             rosdistro_url = 'https://{gh.token}:x-oauth-basic@github.com/{base_org}/{base_repo}.git'.format(**locals())
-            rosdistro_fork_url = 'https://{gh.token}:x-oauth-basic@github.com/{head_org}/{head_repo}.git'.format(**locals())
+            fork_template = 'https://{gh.token}:x-oauth-basic@github.com/{head_org}/{head_repo}.git'
+            rosdistro_fork_url = fork_template.format(**locals())
             _my_run('mkdir -p {base_repo}'.format(**locals()))
             with change_directory(base_repo):
                 _my_run('git init')

--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -800,52 +800,8 @@ def open_pull_request(track, repository, distro, interactive, override_release_r
     # If we did replace the branch in the url with a commit, restore that now
     if _rosdistro_index_original_branch is not None:
         base_branch = _rosdistro_index_original_branch
-    # Get the github interface
-    gh = get_github_interface()
-    if gh is None:
-        return None
-    # Determine the head org/repo for the pull request
-    head_org = gh.username  # The head org will always be gh user
-    head_repo = None
-    # Check if the github user and the base org are the same
-    if gh.username == base_org:
-        # If it is, then a fork is not necessary
-        head_repo = gh.get_repo(base_org, base_repo)
-    else:
-        info(fmt("@{bf}@!==> @|@!Checking on GitHub for a fork to make the pull request from..."))
-        # It is not, so a fork will be required
-        # Check if a fork already exists on the user's account
 
-        try:
-            repo_forks = gh.list_forks(base_org, base_repo)
-            user_forks = [r for r in repo_forks if r.get('owner', {}).get('login', '') == gh.username]
-            # github allows only 1 fork per org as far as I know. We just take the first one.
-            head_repo = user_forks[0] if user_forks else None
-
-        except GithubException as exc:
-            debug("Received GithubException while checking for fork: {exc}".format(**locals()))
-            pass  # 404 or unauthorized, but unauthorized should have been caught above
-
-        # If not head_repo still, a fork does not exist and must be created
-        if head_repo is None:
-            warning("Could not find a fork of {base_org}/{base_repo} on the {gh.username} GitHub account."
-                    .format(**locals()))
-            warning("Would you like to create one now?")
-            if not maybe_continue():
-                warning("Skipping the pull request...")
-                return
-            # Create a fork
-            try:
-                head_repo = gh.create_fork(base_org, base_repo)  # Will raise if not successful
-            except GithubException as exc:
-                error("Aborting pull request: {0}".format(exc))
-                return
-    head_repo = head_repo.get('name', '')
-    info(fmt("@{bf}@!==> @|@!" +
-             "Using this fork to make a pull request from: {head_org}/{head_repo}".format(**locals())))
-    # Clone the fork
-    info(fmt("@{bf}@!==> @|@!" + "Cloning {0}/{1}...".format(head_org, head_repo)))
-    new_branch = None
+    # Create content for PR
     title = "{0}: {1} in '{2}' [bloom]".format(repository, version, base_path)
     track_dict = get_tracks_dict_raw()['tracks'][track]
     body = u"""\
@@ -866,50 +822,99 @@ Increasing version of package(s) in repository `{repository}` to `{version}`:
         release_repo=updated_distribution_file.repositories[repository].release_repository.url,
     )
     body += get_changelog_summary(generate_release_tag(distro))
-    with temporary_directory() as temp_dir:
-        def _my_run(cmd, msg=None):
-            if msg:
-                info(fmt("@{bf}@!==> @|@!" + sanitize(msg)))
-            else:
-                info(fmt("@{bf}@!==> @|@!" + sanitize(str(cmd))))
-            from subprocess import check_call
-            check_call(cmd, shell=True)
-        # Use the oauth token to clone
-        rosdistro_url = 'https://{gh.token}:x-oauth-basic@github.com/{base_org}/{base_repo}.git'.format(**locals())
-        rosdistro_fork_url = 'https://{gh.token}:x-oauth-basic@github.com/{head_org}/{head_repo}.git'.format(**locals())
-        _my_run('mkdir -p {base_repo}'.format(**locals()))
-        with change_directory(base_repo):
-            _my_run('git init')
-            branches = [x['name'] for x in gh.list_branches(head_org, head_repo)]
-            new_branch = 'bloom-{repository}-{count}'
-            count = 0
-            while new_branch.format(repository=repository, count=count) in branches:
-                count += 1
-            new_branch = new_branch.format(repository=repository, count=count)
-            # Final check
-            info(fmt("@{cf}Pull Request Title: @{yf}" + sanitize(title)))
-            info(fmt("@{cf}Pull Request Body : \n@{yf}" + sanitize(body)))
-            msg = fmt("@!Open a @|@{cf}pull request@| @!@{kf}from@| @!'@|@!@{bf}" +
-                      "{head_org}/{head_repo}:{new_branch}".format(**locals()) +
-                      "@|@!' @!@{kf}into@| @!'@|@!@{bf}" +
-                      "{base_org}/{base_repo}:{base_branch}".format(**locals()) +
-                      "@|@!'?")
-            info(msg)
-            if interactive and not maybe_continue():
-                warning("Skipping the pull request...")
-                return
-            _my_run('git checkout -b {new_branch}'.format(**locals()))
-            _my_run('git pull {rosdistro_url} {base_branch}'.format(**locals()), "Pulling latest rosdistro branch")
-            if _rosdistro_index_commit is not None:
-                _my_run('git reset --hard {_rosdistro_index_commit}'.format(**globals()))
-            with open('{0}'.format(base_path), 'w') as f:
-                info(fmt("@{bf}@!==> @|@!Writing new distribution file: ") + str(base_path))
-                f.write(updated_distro_file_yaml)
-            _my_run('git add {0}'.format(base_path))
-            _my_run('git commit -m "{0}"'.format(title))
-            _my_run('git push {rosdistro_fork_url} {new_branch}'.format(**locals()), "Pushing changes to fork")
-    # Open the pull request
-    return gh.create_pull_request(base_org, base_repo, base_branch, head_org, new_branch, title, body)
+
+    if True:
+        # Get the github interface
+        gh = get_github_interface()
+        if gh is None:
+            return None
+        # Determine the head org/repo for the pull request
+        head_org = gh.username  # The head org will always be gh user
+        head_repo = None
+        # Check if the github user and the base org are the same
+        if gh.username == base_org:
+            # If it is, then a fork is not necessary
+            head_repo = gh.get_repo(base_org, base_repo)
+        else:
+            info(fmt("@{bf}@!==> @|@!Checking on GitHub for a fork to make the pull request from..."))
+            # It is not, so a fork will be required
+            # Check if a fork already exists on the user's account
+
+            try:
+                repo_forks = gh.list_forks(base_org, base_repo)
+                user_forks = [r for r in repo_forks if r.get('owner', {}).get('login', '') == gh.username]
+                # github allows only 1 fork per org as far as I know. We just take the first one.
+                head_repo = user_forks[0] if user_forks else None
+
+            except GithubException as exc:
+                debug("Received GithubException while checking for fork: {exc}".format(**locals()))
+                pass  # 404 or unauthorized, but unauthorized should have been caught above
+
+            # If not head_repo still, a fork does not exist and must be created
+            if head_repo is None:
+                warning("Could not find a fork of {base_org}/{base_repo} on the {gh.username} GitHub account."
+                        .format(**locals()))
+                warning("Would you like to create one now?")
+                if not maybe_continue():
+                    warning("Skipping the pull request...")
+                    return
+                # Create a fork
+                try:
+                    head_repo = gh.create_fork(base_org, base_repo)  # Will raise if not successful
+                except GithubException as exc:
+                    error("Aborting pull request: {0}".format(exc))
+                    return
+        head_repo = head_repo.get('name', '')
+        info(fmt("@{bf}@!==> @|@!" +
+                 "Using this fork to make a pull request from: {head_org}/{head_repo}".format(**locals())))
+        # Clone the fork
+        info(fmt("@{bf}@!==> @|@!" + "Cloning {0}/{1}...".format(head_org, head_repo)))
+        new_branch = None
+
+        with temporary_directory() as temp_dir:
+            def _my_run(cmd, msg=None):
+                if msg:
+                    info(fmt("@{bf}@!==> @|@!" + sanitize(msg)))
+                else:
+                    info(fmt("@{bf}@!==> @|@!" + sanitize(str(cmd))))
+                from subprocess import check_call
+                check_call(cmd, shell=True)
+            # Use the oauth token to clone
+            rosdistro_url = 'https://{gh.token}:x-oauth-basic@github.com/{base_org}/{base_repo}.git'.format(**locals())
+            rosdistro_fork_url = 'https://{gh.token}:x-oauth-basic@github.com/{head_org}/{head_repo}.git'.format(**locals())
+            _my_run('mkdir -p {base_repo}'.format(**locals()))
+            with change_directory(base_repo):
+                _my_run('git init')
+                branches = [x['name'] for x in gh.list_branches(head_org, head_repo)]
+                new_branch = 'bloom-{repository}-{count}'
+                count = 0
+                while new_branch.format(repository=repository, count=count) in branches:
+                    count += 1
+                new_branch = new_branch.format(repository=repository, count=count)
+                # Final check
+                info(fmt("@{cf}Pull Request Title: @{yf}" + sanitize(title)))
+                info(fmt("@{cf}Pull Request Body : \n@{yf}" + sanitize(body)))
+                msg = fmt("@!Open a @|@{cf}pull request@| @!@{kf}from@| @!'@|@!@{bf}" +
+                          "{head_org}/{head_repo}:{new_branch}".format(**locals()) +
+                          "@|@!' @!@{kf}into@| @!'@|@!@{bf}" +
+                          "{base_org}/{base_repo}:{base_branch}".format(**locals()) +
+                          "@|@!'?")
+                info(msg)
+                if interactive and not maybe_continue():
+                    warning("Skipping the pull request...")
+                    return
+                _my_run('git checkout -b {new_branch}'.format(**locals()))
+                _my_run('git pull {rosdistro_url} {base_branch}'.format(**locals()), "Pulling latest rosdistro branch")
+                if _rosdistro_index_commit is not None:
+                    _my_run('git reset --hard {_rosdistro_index_commit}'.format(**globals()))
+                with open('{0}'.format(base_path), 'w') as f:
+                    info(fmt("@{bf}@!==> @|@!Writing new distribution file: ") + str(base_path))
+                    f.write(updated_distro_file_yaml)
+                _my_run('git add {0}'.format(base_path))
+                _my_run('git commit -m "{0}"'.format(title))
+                _my_run('git push {rosdistro_fork_url} {new_branch}'.format(**locals()), "Pushing changes to fork")
+        # Open the pull request
+        return gh.create_pull_request(base_org, base_repo, base_branch, head_org, new_branch, title, body)
 
 _original_version = None
 


### PR DESCRIPTION
In order to make #458 easier to merge, I've made this branch which just reorders some of the core commands such that 
 * The content for the PR is created first, followed by the github specific logic.
 * The github is hidden behind a `if True` block, so that future whitespace changes are not needed. 

Let me know if this helps @nuclearsandwich 