### PR TITLE
Travis CI: Add Python 3.7 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ python:
   - "2.7"
   - "3.4"
   - "3.6"
+matrix:
+  include:
+    - python: "3.7"
+      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
 # command to install dependencies
 install:
   - pip install PyYAML argparse rosdep vcstools catkin-pkg python-dateutil setuptools


### PR DESCRIPTION
Add Python 3.7 to the testing in alignment with travis-ci/travis-ci#9069