### PR TITLE
Add smoke test for `bloom-release -h`.

### DIFF
--- a/test/system_tests/test_bloom_release.py
+++ b/test/system_tests/test_bloom_release.py
@@ -1,0 +1,5 @@
+from ..utils.common import user
+
+def test_bloom_release_dash_h():
+    assert 0 == user('bloom-release -h'), "Exited with non-zero status."
+


### PR DESCRIPTION
Add a very basic "smoke test" for syntax issues in the bloom-release command.