### PR TITLE
Prepare release of 0.6.7.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+0.6.7 (2018-09-24 06:30:00 -0800)
+---------------------------------
+- Added debian/copyright file to debian package when license file is specified in package.xml. `#470 <https://github.com/ros-infrastructure/bloom/pull/470>`_
+- Refactored release command to prepare for GitLab pull request support. `#483 <https://github.com/ros-infrastructure/bloom/pull/483>`_
+- Fixed outdated GitHub URL in help text. `#484 <https://github.com/ros-infrastructure/bloom/pull/484>`_
+- Added entry to tracks.yaml to store the upstream tag of the last release. `#472 <https://github.com/ros-infrastructure/bloom/pull/472>`_
+
 0.6.6 (2018-06-28 19:44:00 -0800)
 ---------------------------------
 - Updated vendor typesupport injection for ROS 2. `#477 <https://github.com/ros-infrastructure/bloom/pull/477>`_

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if sys.version_info[0] == 2 and sys.version_info[1] <= 6:
 
 setup(
     name='bloom',
-    version='0.6.6',
+    version='0.6.7',
     packages=find_packages(exclude=['test', 'test.*']),
     package_data={
         'bloom.generators.debian': [


### PR DESCRIPTION
PR opened for visibility. This commit will be fast-forwarded directly onto master.

Changes:
*    Added debian/copyright file to debian package when license file is specified in package.xml. #470
*   Refactored release command to prepare for GitLab pull request support. #483
*   Fixed outdated GitHub URL in help text. #484
*   Added entry to tracks.yaml to store the upstream tag of the last release. #472

With thanks to @DLu, @otamachan, and @wjwwood for their contributions and review. :balloon: 