### PR TITLE
Quote files removed with `git rm -rf`.

### DIFF
--- a/bloom/commands/git/patch/trim_cmd.py
+++ b/bloom/commands/git/patch/trim_cmd.py
@@ -104,7 +104,7 @@ def _trim(config, force, directory):
             items.append(item)
         # Remove and .* files missed by 'git rm -rf *'
         if len(items) > 0:
-            execute_command('git rm -rf ' + ' '.join(['"%s"' % i for i in items if i]), cwd=directory)
+            execute_command('git rm -rf ' + ' '.join(["'{}'".format(i) for i in items if i]), cwd=directory)
         # Copy the sub directory back
         for item in os.listdir(storage):
             src = os.path.join(storage, item)

--- a/bloom/commands/git/patch/trim_cmd.py
+++ b/bloom/commands/git/patch/trim_cmd.py
@@ -104,7 +104,7 @@ def _trim(config, force, directory):
             items.append(item)
         # Remove and .* files missed by 'git rm -rf *'
         if len(items) > 0:
-            execute_command('git rm -rf ' + ' '.join(items), cwd=directory)
+            execute_command('git rm -rf ' + ' '.join(['"%s"' % i for i in items if i]), cwd=directory)
         # Copy the sub directory back
         for item in os.listdir(storage):
             src = os.path.join(storage, item)

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -885,7 +885,7 @@ class DebianGenerator(BloomGenerator):
         template_files = process_template_files('.', subs)
         # Remove any residual template files
         execute_command('git rm -rf ' +
-            ' '.join("'%s'".format(t) for t in template_files))
+            ' '.join("'{}'".format(t) for t in template_files))
         # Add changes to the debian folder
         execute_command('git add debian')
         # Commit changes

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -884,7 +884,8 @@ class DebianGenerator(BloomGenerator):
         # Template files
         template_files = process_template_files('.', subs)
         # Remove any residual template files
-        execute_command('git rm -rf ' + ' '.join(template_files))
+        execute_command('git rm -rf ' +
+            ' '.join("'%s'".format(t) for t in template_files))
         # Add changes to the debian folder
         execute_command('git add debian')
         # Commit changes

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -884,8 +884,7 @@ class DebianGenerator(BloomGenerator):
         # Template files
         template_files = process_template_files('.', subs)
         # Remove any residual template files
-        execute_command('git rm -rf ' +
-            ' '.join("'{}'".format(t) for t in template_files))
+        execute_command('git rm -rf ' + ' '.join("'{}'".format(t) for t in template_files))
         # Add changes to the debian folder
         execute_command('git add debian')
         # Commit changes

--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -764,7 +764,7 @@ class RpmGenerator(BloomGenerator):
         template_files = process_template_files('.', subs)
         # Remove any residual template files
         execute_command('git rm -rf ' +
-                ' '.join("'%s'".format(t) for t in template_files))
+                ' '.join("'{}'".format(t) for t in template_files))
         # Add changes to the rpm folder
         execute_command('git add ' + rpm_dir)
         # Commit changes

--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -763,8 +763,7 @@ class RpmGenerator(BloomGenerator):
         # Template files
         template_files = process_template_files('.', subs)
         # Remove any residual template files
-        execute_command('git rm -rf ' +
-                ' '.join("'{}'".format(t) for t in template_files))
+        execute_command('git rm -rf ' + ' '.join("'{}'".format(t) for t in template_files))
         # Add changes to the rpm folder
         execute_command('git add ' + rpm_dir)
         # Commit changes

--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -763,7 +763,8 @@ class RpmGenerator(BloomGenerator):
         # Template files
         template_files = process_template_files('.', subs)
         # Remove any residual template files
-        execute_command('git rm -rf ' + ' '.join(template_files))
+        execute_command('git rm -rf ' +
+                ' '.join("'%s'".format(t) for t in template_files))
         # Add changes to the rpm folder
         execute_command('git add ' + rpm_dir)
         # Commit changes


### PR DESCRIPTION
In some places we were quoting removed files and in others we weren't. I did a grep through the codebase for `rm -rf` to catch the case mentioned in #450 as well as potentially others in the template file names.

Resolves #450. 