### PR TITLE
Update minimum version of rosdistro to support rosdistro index v4.

### DIFF
--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -120,8 +120,8 @@ from vcstools.vcs_abstraction import get_vcs_client
 
 try:
     import rosdistro
-    if parse_version(rosdistro.__version__) < parse_version('0.4.0'):
-        error("rosdistro version 0.4.0 or greater is required, found '{0}' from '{1}'."
+    if parse_version(rosdistro.__version__) < parse_version('0.7.0'):
+        error("rosdistro version 0.7.0 or greater is required, found '{0}' from '{1}'."
               .format(rosdistro.__version__, os.path.dirname(rosdistro.__file__)),
               exit=True)
 except ImportError:
@@ -218,7 +218,7 @@ def get_index():
             error("This version of bloom does not support rosdistro version "
                   "'{0}', please use an older version of bloom."
                   .format(_rosdistro_index.version), exit=True)
-        if _rosdistro_index.version > 3:
+        if _rosdistro_index.version > 4:
             error("This version of bloom does not support rosdistro version "
                   "'{0}', please update bloom.".format(_rosdistro_index.version), exit=True)
     return _rosdistro_index

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
     'python-dateutil',
     'PyYAML',
     'rosdep >= 0.10.25',
-    'rosdistro >= 0.4.0',
+    'rosdistro >= 0.7.0',
     'vcstools >= 0.1.22',
 ]
 

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
-Depends: python-yaml, python-empy, python-argparse, python-rosdep (>= 0.10.25), python-rosdistro (>= 0.4.0), python-vcstools (>= 0.1.22), python-setuptools, python-catkin-pkg (>= 0.4.3)
-Depends3: python3-yaml, python3-empy, python3-rosdep (>= 0.10.25), python3-rosdistro (>= 0.4.0), python3-vcstools (>= 0.1.22), python3-setuptools, python3-catkin-pkg (>= 0.4.3)
+Depends: python-yaml, python-empy, python-argparse, python-rosdep (>= 0.10.25), python-rosdistro (>= 0.7.0), python-vcstools (>= 0.1.22), python-setuptools, python-catkin-pkg (>= 0.4.3)
+Depends3: python3-yaml, python3-empy, python3-rosdep (>= 0.10.25), python3-rosdistro (>= 0.7.0), python3-vcstools (>= 0.1.22), python3-setuptools, python3-catkin-pkg (>= 0.4.3)
 Conflicts: python3-bloom
 Conflicts3: python-bloom
 Copyright-File: LICENSE.txt


### PR DESCRIPTION
For now we don't make any use of the new distribution data in index v4.
This is a minimal update to fix failures with bloom due to the version
restrictions.

This PR has been tested locally.