### PR TITLE
use yaml.safe_load for untrusted yaml input

### DIFF
--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -657,7 +657,7 @@ def generate_ros_distro_diff(track, repository, distro, override_release_reposit
                 udiff_raw += line
             info(line, use_prefix=False, end='')
         # Assert that only this repository is being changed
-        distro_file_yaml = yaml.load(distro_file_raw)
+        distro_file_yaml = yaml.safe_load(distro_file_raw)
         distro_yaml = yaml.load(distro_dump)
         if 'repositories' in distro_file_yaml:
             distro_file_repos = distro_file_yaml['repositories']

--- a/bloom/config.py
+++ b/bloom/config.py
@@ -273,7 +273,7 @@ def get_tracks_dict_raw(directory=None):
         )
         tracks_yaml = show(BLOOM_CONFIG_BRANCH, 'tracks.yaml',
                            directory=directory)
-    tracks_dict = yaml.load(tracks_yaml)
+    tracks_dict = yaml.safe_load(tracks_yaml)
     validate_track_versions(tracks_dict)
     return tracks_dict
 


### PR DESCRIPTION
The patch only updates the invocation where untrusted sources are being processed.