### PR TITLE
Require rosdep 0.15.0 in order to handle conditions in dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ install_requires = [
     'empy',
     'python-dateutil',
     'PyYAML',
-    'rosdep >= 0.10.25',
+    'rosdep >= 0.15.0',
     'rosdistro >= 0.7.0',
     'vcstools >= 0.1.22',
 ]

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
-Depends: python-yaml, python-empy, python-argparse, python-rosdep (>= 0.10.25), python-rosdistro (>= 0.7.0), python-vcstools (>= 0.1.22), python-setuptools, python-catkin-pkg (>= 0.4.3)
-Depends3: python3-yaml, python3-empy, python3-rosdep (>= 0.10.25), python3-rosdistro (>= 0.7.0), python3-vcstools (>= 0.1.22), python3-setuptools, python3-catkin-pkg (>= 0.4.3)
+Depends: python-yaml, python-empy, python-argparse, python-rosdep (>= 0.15.0), python-rosdistro (>= 0.7.0), python-vcstools (>= 0.1.22), python-setuptools, python-catkin-pkg (>= 0.4.3)
+Depends3: python3-yaml, python3-empy, python3-rosdep (>= 0.15.0), python3-rosdistro (>= 0.7.0), python3-vcstools (>= 0.1.22), python3-setuptools, python3-catkin-pkg (>= 0.4.3)
 Conflicts: python3-bloom
 Conflicts3: python-bloom
 Copyright-File: LICENSE.txt


### PR DESCRIPTION
As of 0.15.0 rosdep evaluates package format 3 conditions before resolving dependencies (https://github.com/ros-infrastructure/rosdep/pull/654). In order for bloom to support them as well it needs that version of rosdep.