### PR TITLE
Only release on platforms supported by rosdistro 0.7.0.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -4,5 +4,5 @@ Depends3: python3-yaml, python3-empy, python3-rosdep (>= 0.15.0), python3-rosdis
 Conflicts: python3-bloom
 Conflicts3: python-bloom
 Copyright-File: LICENSE.txt
-Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty artful bionic wheezy jessie stretch buster
+Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic jessie stretch buster
 X-Python3-Version: >= 3.2

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -5,4 +5,4 @@ Conflicts: python3-bloom
 Conflicts3: python-bloom
 Copyright-File: LICENSE.txt
 Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic jessie stretch buster
-X-Python3-Version: >= 3.2
+X-Python3-Version: >= 3.4


### PR DESCRIPTION
Closes a packaging regression on platforms no longer supported by
current rosdistro releases.

As of https://github.com/ros-infrastructure/bloom/pull/493 (first released in 0.6.8) we're relying on a version of rosdistro which is not supported by older Ubuntu and Debian releases (https://github.com/ros-infrastructure/rosdistro/pull/123). A recent release of rosdep [brought the issue to our attention](https://discourse.ros.org/t/rosdep-and-eol-distros/7640).

In addition to this change for future releases, the 0.6.8, 0.6.9, 0.7.0, 0.7.1, and 0.7.2 releases will be yanked from the platforms removed below to fix the regression.