### PR TITLE
Set Git author/committer within tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ install:
   - cd -
   - sudo `which rosdep` init
   - rosdep update
-  - git config --global user.email "test@example.com"
-  - git config --global user.name "Test User"
 # command to run tests
 script:
   - BLOOM_VERBOSE=1 python setup.py nosetests -s --tests test

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -5,3 +5,11 @@ if 'PATH' in os.environ:
     scripts = os.path.join(os.path.dirname(__file__), '..', 'scripts')
     scripts = os.path.abspath(scripts)
     os.environ['PATH'] = scripts + ':' + os.environ['PATH']
+
+user_email = 'test@example.com'
+user_name = 'Test User'
+
+os.environ.setdefault('GIT_AUTHOR_NAME', user_name)
+os.environ.setdefault('GIT_AUTHOR_EMAIL', user_email)
+os.environ.setdefault('GIT_COMMITTER_NAME', user_name)
+os.environ.setdefault('GIT_COMMITTER_EMAIL', user_email)


### PR DESCRIPTION
This removes the environmental requirement that Git be configured prior to running the tests.

Git environment variable documentation: https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables