### PR TITLE
Make tests runnable outside of a git repository

### DIFF
--- a/test/unit_tests/test_packages.py
+++ b/test/unit_tests/test_packages.py
@@ -1,14 +1,19 @@
 import os
 
 from ..utils.common import AssertRaisesContext
+from ..utils.common import in_temporary_directory
 from ..utils.common import redirected_stdio
+from ..utils.common import user
 
 from bloom.packages import get_package_data
 
 test_data_dir = os.path.join(os.path.dirname(__file__), 'test_packages_data')
 
 
+@in_temporary_directory
 def test_get_package_data_fails_on_uppercase():
+    user('git init .')
+
     with AssertRaisesContext(SystemExit, "Invalid package names, aborting."):
         with redirected_stdio():
             get_package_data(directory=test_data_dir)


### PR DESCRIPTION
This is never encountered on Travis, but this test assumes that the CWD is a git repository.