### PR TITLE
Evaluate dependency conditions

### DIFF
--- a/bloom/generators/common.py
+++ b/bloom/generators/common.py
@@ -40,6 +40,8 @@ from bloom.logging import debug
 from bloom.logging import error
 from bloom.logging import info
 
+from bloom.rosdistro_api import get_distribution_type
+
 from bloom.util import code
 from bloom.util import maybe_continue
 from bloom.util import print_exc
@@ -115,6 +117,21 @@ def resolve_more_for_os(rosdep_key, view, installer, os_name, os_version):
                                              default_os_installer)
     assert inst_key in os_installers
     return installer.resolve(rule), inst_key, default_os_installer
+
+
+def package_conditional_context(ros_distro):
+    distribution_type = get_distribution_type(ros_distro)
+    if distribution_type == 'ros1':
+        ros_version = '1'
+    elif distribution_type == 'ros2':
+        ros_version = '2'
+    else:
+        error("Bloom cannot cope with distribution_type '{0}'".format(
+            distribution_type), exit=True)
+    return {
+            'ROS_VERSION': ros_version,
+            'ROS_DISTRO': ros_distro,
+            }
 
 
 def resolve_rosdep_key(

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -312,10 +312,17 @@ def generate_substitutions_from_package(
     # Installation prefix
     data['InstallationPrefix'] = installation_prefix
     # Resolve dependencies
-    depends = package.run_depends + package.buildtool_export_depends
-    build_depends = package.build_depends + package.buildtool_depends + package.test_depends
+    package.evaluate_conditions(os.environ)
+    depends = [
+        dep for dep in (package.run_depends + package.buildtool_export_depends)
+        if dep.evaluated_condition]
+    build_depends = [
+        dep for dep in (package.build_depends + package.buildtool_depends + package.test_depends)
+        if dep.evaluated_condition]
 
-    unresolved_keys = depends + build_depends + package.replaces + package.conflicts
+    unresolved_keys = [
+        dep for dep in (depends + build_depends + package.replaces + package.conflicts)
+        if dep.evaluated_condition]
     # The installer key is not considered here, but it is checked when the keys are checked before this
     resolved_deps = resolve_dependencies(unresolved_keys, os_name,
                                          os_version, ros_distro,

--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -526,7 +526,7 @@ class RpmGenerator(BloomGenerator):
         update_rosdep()
         self.has_run_rosdep = True
 
-    def _check_all_keys_are_valid(self, peer_packages):
+    def _check_all_keys_are_valid(self, peer_packages, rosdistro):
         keys_to_resolve = []
         key_to_packages_which_depends_on = collections.defaultdict(list)
         keys_to_ignore = set()

--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -578,7 +578,7 @@ class RpmGenerator(BloomGenerator):
 
         peer_packages = [p.name for p in self.packages.values()]
 
-        while not self._check_all_keys_are_valid(peer_packages):
+        while not self._check_all_keys_are_valid(peer_packages, self.rosdistro):
             error("Some of the dependencies for packages in this repository could not be resolved by rosdep.")
             error("You can try to address the issues which appear above and try again if you wish, "
                   "or continue without releasing into RPM-based distributions (e.g. Fedora 24).")


### PR DESCRIPTION
Noodling on this approach in order to try and unblock @AAlon.

Quite aside from the clear need to factor the condition check into a function, a few other things stand out as worth considering before merging:
* For consistent results, maybe we could get our context from the bloom tracks.yaml rather than the environment
* I used comprehensions to filter conditions on lists of dependencies roughly in place but it's worth looking more closely (at a better time of day) to see if there's any reason not to check the evaluated conditions lazily after the list of keys to evaluate is generated rather than doing it on each list as its constructed.

An additional TODO is to check that the build_type condition is also checked and honored.