### PR TITLE
fix str vs bytes issue in python3

### DIFF
--- a/bloom/github.py
+++ b/bloom/github.py
@@ -73,7 +73,10 @@ import bloom
 
 
 def auth_header_from_basic_auth(user, password):
-    return "Basic {0}".format(base64.b64encode('{0}:{1}'.format(user, password)))
+    auth_str = '{0}:{1}'.format(user, password)
+    if sys.version_info >= (3, 0):
+        auth_str = auth_str.encode()
+    return "Basic {0}".format(base64.b64encode(auth_str))
 
 
 def auth_header_from_oauth_token(token):


### PR DESCRIPTION
Otherwise you get an error like this:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/bloom/commands/release.py", line 1323, in perform_release
    track, repository, distro, interactive, override_release_repository_url
  File "/usr/local/lib/python3.7/site-packages/bloom/commands/release.py", line 867, in open_pull_request
    gh = get_github_interface()
  File "/usr/local/lib/python3.7/site-packages/bloom/commands/release.py", line 759, in get_github_interface
    gh = Github(username, auth=auth_header_from_basic_auth(username, password))
  File "/usr/local/lib/python3.7/site-packages/bloom/github.py", line 65, in auth_header_from_basic_auth
    return "Basic {0}".format(base64.b64encode('{0}:{1}'.format(user, password)))
  File "/usr/local/Cellar/python/3.7.2_2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/base64.py", line 58, in b64encode
    encoded = binascii.b2a_base64(s, newline=False)
TypeError: a bytes-like object is required, not 'str'

Failed to open pull request: TypeError - a bytes-like object is required, not 'str'
```