### PR TITLE
fix issue 518

### DIFF
--- a/bloom/commands/generate.py
+++ b/bloom/commands/generate.py
@@ -67,7 +67,7 @@ def create_subparsers(parser, generator_cmds):
     for generator_cmd in generator_cmds:
         desc = load_generator_description(generator_cmd)
         cmd_parser = subparser.add_parser(desc['title'], description=desc['description'])
-        cmd_parser = desc['prepare_arguments'](cmd_parser)
+        desc['prepare_arguments'](cmd_parser)
         cmd_parser.set_defaults(func=desc['main'])
         add_global_arguments(cmd_parser)
 

--- a/bloom/generators/common.py
+++ b/bloom/generators/common.py
@@ -218,7 +218,8 @@ class BloomGenerator(object):
     def exit(cls, msg, returncode=code.UNKNOWN):
         raise GeneratorError(msg, returncode)
 
-    def prepare_arguments(self, parser):
+    @staticmethod
+    def prepare_arguments(parser):
         """
         Argument preparation hook, should be implemented in child class
 

--- a/bloom/generators/debian/generate_cmd.py
+++ b/bloom/generators/debian/generate_cmd.py
@@ -76,7 +76,6 @@ def prepare_arguments(parser):
     add('--os-version', help='OS version or codename, e.g. precise, wheezy')
     add('--ros-distro', help="ROS distro, e.g. %s (used for rosdep)" % get_distro_list_prompt())
     add('--native', action='store_true', help="generate native package")
-    return parser
 
 
 def get_subs(pkg, os_name, os_version, ros_distro, native=False):

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -571,7 +571,8 @@ class DebianGenerator(BloomGenerator):
     default_install_prefix = '/usr'
     rosdistro = os.environ.get('ROS_DISTRO', 'indigo')
 
-    def prepare_arguments(self, parser):
+    @staticmethod
+    def prepare_arguments(parser):
         # Add command line arguments for this generator
         add = parser.add_argument
         add('-i', '--debian-inc', help="debian increment number", default='0')

--- a/bloom/generators/release.py
+++ b/bloom/generators/release.py
@@ -72,7 +72,8 @@ each package in the upstream repository, so the source branch should be set to
 'upstream' and the prefix set to 'release'.
 """
 
-    def prepare_arguments(self, parser):
+    @staticmethod
+    def prepare_arguments(parser):
         # Add command line arguments for this generator
         add = parser.add_argument
         add('-s', '--src', '--source-branch', default=None, dest='src',
@@ -83,7 +84,7 @@ each package in the upstream repository, so the source branch should be set to
             help="prefix for target branch name(s)")
         add('--release-increment', '-i', default=0,
             help="release increment number")
-        return BloomGenerator.prepare_arguments(self, parser)
+        return BloomGenerator.prepare_arguments(parser)
 
     def handle_arguments(self, args):
         self.interactive = args.interactive

--- a/bloom/generators/rosdebian.py
+++ b/bloom/generators/rosdebian.py
@@ -40,7 +40,6 @@ from bloom.generators.debian.generator import sanitize_package_name
 from bloom.generators.debian import DebianGenerator
 from bloom.generators.debian.generator import generate_substitutions_from_package
 from bloom.generators.debian.generate_cmd import main as debian_main
-from bloom.generators.debian.generate_cmd import prepare_arguments
 
 from bloom.logging import info
 
@@ -54,11 +53,12 @@ class RosDebianGenerator(DebianGenerator):
     description = "Generates debians tailored for the given rosdistro"
     default_install_prefix = '/opt/ros/'
 
-    def prepare_arguments(self, parser):
+    @staticmethod
+    def prepare_arguments(parser):
         # Add command line arguments for this generator
         add = parser.add_argument
         add('rosdistro', help="ROS distro to target (%s, etc.)" % get_distro_list_prompt())
-        return DebianGenerator.prepare_arguments(self, parser)
+        return DebianGenerator.prepare_arguments(parser)
 
     def handle_arguments(self, args):
         self.rosdistro = args.rosdistro
@@ -162,5 +162,5 @@ description = dict(
     title='rosdebian',
     description="Generates ROS style debian packaging files for a catkin package",
     main=main,
-    prepare_arguments=prepare_arguments
+    prepare_arguments=RosDebianGenerator.prepare_arguments
 )

--- a/bloom/generators/rosrelease.py
+++ b/bloom/generators/rosrelease.py
@@ -22,11 +22,12 @@ repository, so the source branch should be set to 'upstream' and the
 prefix set to 'release'.
 """
 
-    def prepare_arguments(self, parser):
+    @staticmethod
+    def prepare_arguments(parser):
         # Add command line arguments for this generator
         add = parser.add_argument
         add('rosdistro', help="ROS distro to target (%s, etc.)" % get_distro_list_prompt())
-        return ReleaseGenerator.prepare_arguments(self, parser)
+        return ReleaseGenerator.prepare_arguments(parser)
 
     def handle_arguments(self, args):
         self.rosdistro = args.rosdistro

--- a/bloom/generators/rosrpm.py
+++ b/bloom/generators/rosrpm.py
@@ -40,7 +40,6 @@ from bloom.generators.rpm.generator import sanitize_package_name
 from bloom.generators.rpm import RpmGenerator
 from bloom.generators.rpm.generator import generate_substitutions_from_package
 from bloom.generators.rpm.generate_cmd import main as rpm_main
-from bloom.generators.rpm.generate_cmd import prepare_arguments
 
 from bloom.logging import info
 
@@ -52,11 +51,12 @@ class RosRpmGenerator(RpmGenerator):
     description = "Generates RPMs tailored for the given rosdistro"
     default_install_prefix = '/opt/ros/'
 
-    def prepare_arguments(self, parser):
+    @staticmethod
+    def prepare_arguments(parser):
         # Add command line arguments for this generator
         add = parser.add_argument
         add('rosdistro', help="ROS distro to target (%s, etc.)" % get_distro_list_prompt())
-        return RpmGenerator.prepare_arguments(self, parser)
+        return RpmGenerator.prepare_arguments(parser)
 
     def handle_arguments(self, args):
         self.rosdistro = args.rosdistro
@@ -127,5 +127,5 @@ description = dict(
     title='rosrpm',
     description="Generates ROS style RPM packaging files for a catkin package",
     main=main,
-    prepare_arguments=prepare_arguments
+    prepare_arguments=RosRpmGenerator.prepare_arguments
 )

--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -456,7 +456,8 @@ class RpmGenerator(BloomGenerator):
     default_install_prefix = '/usr'
     rosdistro = os.environ.get('ROS_DISTRO', 'indigo')
 
-    def prepare_arguments(self, parser):
+    @staticmethod
+    def prepare_arguments(parser):
         # Add command line arguments for this generator
         add = parser.add_argument
         add('-i', '--rpm-inc', help="RPM increment number", default='0')


### PR DESCRIPTION
The reason why help doc is uncompleted is that wrong prepare_argument function given in [this line](https://github.com/ros-infrastructure/bloom/blob/53f129595d254e4406432c9ef63bf451d252d751/bloom/generators/rosdebian.py#L165). So in this PR, I changed it to point to the right function.