### PR TITLE
Start release increment at 1.

### DIFF
--- a/bloom/commands/git/release.py
+++ b/bloom/commands/git/release.py
@@ -227,7 +227,7 @@ def process_track_settings(track_dict, release_inc_override):
     settings['ros_distro'] = track_dict['ros_distro']
     # Release increment
     if 'last_version' in track_dict and track_dict['last_version'] != version:
-        next_release_inc = str(0)
+        next_release_inc = str(1)
     else:
         next_release_inc = str(int(track_dict['release_inc']) + 1)
     settings['release_inc'] = release_inc_override or next_release_inc

--- a/bloom/config.py
+++ b/bloom/config.py
@@ -190,7 +190,7 @@ DEFAULT_TEMPLATE = {
     'patches': PromptEntry('Patches Directory', spec=config_spec['patches']),
     'ros_distro': PromptEntry('ROS Distro', default='indigo', spec=config_spec['ros_distro']),
     'release_repo_url': PromptEntry('Release Repository Push URL', spec=config_spec['release_repo_url']),
-    'release_inc': -1,
+    'release_inc': 0,
     'actions': [
         'bloom-export-upstream :{vcs_local_uri} :{vcs_type}'
         ' --tag :{release_tag} --display-uri :{vcs_uri}'

--- a/test/system_tests/test_catkin_release.py
+++ b/test/system_tests/test_catkin_release.py
@@ -132,7 +132,7 @@ def _test_unary_package_repository(release_dir, version, directory=None):
             "no patches/release/melodic/foo branch"
         # was the release tag created?
         ret, out, err = user('git tag', return_io=True)
-        expected = 'release/melodic/foo/' + version + '-0'
+        expected = 'release/melodic/foo/' + version + '-1'
         assert out.count(expected) == 1, \
             "no release tag created, expected: '{0}'".format(expected)
 
@@ -266,7 +266,7 @@ def test_multi_package_repository(directory=None):
             assert branch_exists('patches/release/melodic/' + pkg), \
                 "no patches/release/melodic/" + pkg + " branch"
             # Did the release tag get created?
-            assert out.count('release/melodic/' + pkg + '/0.1.0-0') == 1, \
+            assert out.count('release/melodic/' + pkg + '/0.1.0-1') == 1, \
                 "no release tag created for " + pkg
             # Is there a package.xml in the top level?
             with inbranch('release/melodic/' + pkg):
@@ -299,7 +299,7 @@ def test_multi_package_repository(directory=None):
             assert branch_exists('patches/release/melodic/' + pkg), \
                 "no patches/release/melodic/" + pkg + " branch"
             # Did the release tag get created?
-            assert out.count('release/melodic/' + pkg + '/0.1.0-0') == 1, \
+            assert out.count('release/melodic/' + pkg + '/0.1.0-1') == 1, \
                 "no release tag created for " + pkg
             # Is there a package.xml in the top level?
             with inbranch('release/melodic/' + pkg):
@@ -329,7 +329,7 @@ def test_multi_package_repository(directory=None):
                 assert branch_exists(patches_branch), \
                     "no " + patches_branch + " branch"
                 # Did the debian tag get created?
-                tag = 'debian/ros-melodic-' + pkg_san + '_0.1.0-0_' + distro
+                tag = 'debian/ros-melodic-' + pkg_san + '_0.1.0-1_' + distro
                 assert out.count(tag) == 1, \
                     "no '" + tag + "'' tag created for '" + pkg + "': `\n" + \
                     out + "\n`"


### PR DESCRIPTION
Per discussion in https://github.com/ros-infrastructure/bloom/pull/409

This is what most distributions default to and expect.