### PR TITLE
Use yaml.safe_load.

### DIFF
--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -547,7 +547,7 @@ def generate_ros_distro_diff(track, repository, distro, override_release_reposit
             info(line, use_prefix=False, end='')
         # Assert that only this repository is being changed
         distro_file_yaml = yaml.safe_load(distro_file_raw)
-        distro_yaml = yaml.load(distro_dump)
+        distro_yaml = yaml.safe_load(distro_dump)
         if 'repositories' in distro_file_yaml:
             distro_file_repos = distro_file_yaml['repositories']
             for repo in distro_yaml['repositories']:

--- a/test/system_tests/test_bloom_setup.py
+++ b/test/system_tests/test_bloom_setup.py
@@ -49,7 +49,7 @@ def test_create_a_bloom_repository(directory=None):
         assert os.path.exists('tracks.yaml'), \
             "no tracks.yaml file in the 'bloom' branch"
         with open('tracks.yaml', 'r') as f:
-            tracks_dict = yaml.load(f.read())
+            tracks_dict = yaml.safe_load(f.read())
         assert 'tracks' in tracks_dict, "bad bloom configurations"
         assert 'foo' in tracks_dict['tracks'], "bad bloom configurations"
         track = tracks_dict['tracks']['foo']


### PR DESCRIPTION
As neither of these situations require unsafe usage of YAML we should be
able to use the safe loader.