### PR TITLE
Move to 'optional' Priority from 'extra', per Debian Policy 4.0.1

### DIFF
--- a/bloom/generators/debian/templates/ament_cmake/control.em
+++ b/bloom/generators/debian/templates/ament_cmake/control.em
@@ -1,6 +1,6 @@
 Source: @(Package)
 Section: misc
-Priority: extra
+Priority: optional
 Maintainer: @(Maintainer)
 Build-Depends: debhelper (>= @(debhelper_version).0.0), @(', '.join(BuildDepends))
 Homepage: @(Homepage)

--- a/bloom/generators/debian/templates/ament_python/control.em
+++ b/bloom/generators/debian/templates/ament_python/control.em
@@ -1,6 +1,6 @@
 Source: @(Package)
 Section: misc
-Priority: extra
+Priority: optional
 Maintainer: @(Maintainer)
 Build-Depends: debhelper (>= @(debhelper_version).0.0), @(', '.join(BuildDepends)), python3-all, python3-setuptools
 Homepage: @(Homepage)

--- a/bloom/generators/debian/templates/catkin/control.em
+++ b/bloom/generators/debian/templates/catkin/control.em
@@ -1,6 +1,6 @@
 Source: @(Package)
 Section: misc
-Priority: extra
+Priority: optional
 Maintainer: @(Maintainer)
 Build-Depends: debhelper (>= @(debhelper_version).0.0), @(', '.join(BuildDepends))
 Homepage: @(Homepage)

--- a/bloom/generators/debian/templates/cmake/control.em
+++ b/bloom/generators/debian/templates/cmake/control.em
@@ -1,6 +1,6 @@
 Source: @(Package)
 Section: misc
-Priority: extra
+Priority: optional
 Maintainer: @(Maintainer)
 Build-Depends: debhelper (>= @(debhelper_version).0.0), @(', '.join(BuildDepends))
 Homepage: @(Homepage)


### PR DESCRIPTION
Since Debian Policy 4.0.1, the 'extra' Priority has been deprecated in favor of 'optional'. Continuing to issue 'extra' results in lintian warnings. Time to change!

https://lintian.debian.org/tags/priority-extra-is-replaced-by-priority-optional.html

This PR should probably be squashed for merge. Thanks!