### PR TITLE
Improve error handling for package conditions and index files.

### DIFF
--- a/bloom/generators/common.py
+++ b/bloom/generators/common.py
@@ -120,6 +120,13 @@ def resolve_more_for_os(rosdep_key, view, installer, os_name, os_version):
 
 
 def package_conditional_context(ros_distro):
+    """
+    Creates a dict containing the conditional evaluation context for
+    package.xml format three packages.
+
+    :param ros_distro: The codename of the rosdistro to generate context for.
+    :returns: dict defining ROS_VERSION and ROS_DISTRO.
+    """
     distribution_type = get_distribution_type(ros_distro)
     if distribution_type == 'ros1':
         ros_version = '1'

--- a/bloom/generators/common.py
+++ b/bloom/generators/common.py
@@ -144,6 +144,7 @@ def package_conditional_context(ros_distro):
             'ROS_DISTRO': ros_distro,
             }
 
+
 def evaluate_package_conditions(package, ros_distro):
     """
     Evaluates a package's conditional fields.

--- a/bloom/generators/common.py
+++ b/bloom/generators/common.py
@@ -41,6 +41,7 @@ from bloom.logging import error
 from bloom.logging import info
 
 from bloom.rosdistro_api import get_distribution_type
+from bloom.rosdistro_api import get_index
 
 from bloom.util import code
 from bloom.util import maybe_continue
@@ -127,6 +128,9 @@ def package_conditional_context(ros_distro):
     :param ros_distro: The codename of the rosdistro to generate context for.
     :returns: dict defining ROS_VERSION and ROS_DISTRO.
     """
+    if get_index().version < 4:
+        error("Bloom requires a version 4 or greater rosdistro index to support package format 3.", exit=True)
+
     distribution_type = get_distribution_type(ros_distro)
     if distribution_type == 'ros1':
         ros_version = '1'

--- a/bloom/generators/common.py
+++ b/bloom/generators/common.py
@@ -147,7 +147,7 @@ def package_conditional_context(ros_distro):
 
 def evaluate_package_conditions(package, ros_distro):
     """
-    Evaluates a package's conditional fields.
+    Evaluates a package's conditional fields if it supports them.
 
     :param package: The package to be evaluated.
     :param ros_distro: The codename of the rosdistro use for context.
@@ -156,9 +156,7 @@ def evaluate_package_conditions(package, ros_distro):
     # Conditional fields were introduced in package format 3.
     # Earlier formats should have their conditions evaluated with no context so
     # the evaluated_condition is set to True in all cases.
-    if package.package_format < 3:
-        package.evaluate_conditions({})
-    else:
+    if package.package_format >= 3:
         package.evaluate_conditions(package_conditional_context(ros_distro))
 
 

--- a/bloom/generators/common.py
+++ b/bloom/generators/common.py
@@ -144,6 +144,22 @@ def package_conditional_context(ros_distro):
             'ROS_DISTRO': ros_distro,
             }
 
+def evaluate_package_conditions(package, ros_distro):
+    """
+    Evaluates a package's conditional fields.
+
+    :param package: The package to be evaluated.
+    :param ros_distro: The codename of the rosdistro use for context.
+    :returns: None. The given package will be modified.
+    """
+    # Conditional fields were introduced in package format 3.
+    # Earlier formats should have their conditions evaluated with no context so
+    # the evaluated_condition is set to True in all cases.
+    if package.package_format < 3:
+        package.evaluate_conditions({})
+    else:
+        package.evaluate_conditions(package_conditional_context(ros_distro))
+
 
 def resolve_rosdep_key(
     key,

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -316,14 +316,14 @@ def generate_substitutions_from_package(
     evaluate_package_conditions(package, ros_distro)
     depends = [
         dep for dep in (package.run_depends + package.buildtool_export_depends)
-        if dep.evaluated_condition]
+        if dep.evaluated_condition is not False]
     build_depends = [
         dep for dep in (package.build_depends + package.buildtool_depends + package.test_depends)
-        if dep.evaluated_condition]
+        if dep.evaluated_condition is not False]
 
     unresolved_keys = [
         dep for dep in (depends + build_depends + package.replaces + package.conflicts)
-        if dep.evaluated_condition]
+        if dep.evaluated_condition is not False]
     # The installer key is not considered here, but it is checked when the keys are checked before this
     resolved_deps = resolve_dependencies(unresolved_keys, os_name,
                                          os_version, ros_distro,
@@ -663,16 +663,16 @@ class DebianGenerator(BloomGenerator):
             evaluate_package_conditions(package, ros_distro)
             depends = [
                 dep for dep in (package.run_depends + package.buildtool_export_depends)
-                if dep.evaluated_condition]
+                if dep.evaluated_condition is not False]
             build_depends = [
                 dep for dep in (package.build_depends + package.buildtool_depends + package.test_depends)
-                if dep.evaluated_condition]
+                if dep.evaluated_condition is not False]
             unresolved_keys = [
                 dep for dep in (depends + build_depends + package.replaces + package.conflicts)
-                if dep.evaluated_condition]
+                if dep.evaluated_condition is not False]
             keys_to_ignore = {
                     dep for dep in keys_to_ignore.union(package.replaces + package.conflicts)
-                    if dep.evaluated_condition}
+                    if dep.evaluated_condition is not False}
             keys = [d.name for d in unresolved_keys]
             keys_to_resolve.extend(keys)
             for key in keys:

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -58,7 +58,7 @@ from bloom.generators import update_rosdep
 
 from bloom.generators.common import default_fallback_resolver
 from bloom.generators.common import invalidate_view_cache
-from bloom.generators.common import package_conditional_context
+from bloom.generators.common import evaluate_package_conditions
 from bloom.generators.common import resolve_rosdep_key
 
 from bloom.git import inbranch
@@ -313,7 +313,7 @@ def generate_substitutions_from_package(
     # Installation prefix
     data['InstallationPrefix'] = installation_prefix
     # Resolve dependencies
-    package.evaluate_conditions(package_conditional_context(ros_distro))
+    evaluate_package_conditions(package, ros_distro)
     depends = [
         dep for dep in (package.run_depends + package.buildtool_export_depends)
         if dep.evaluated_condition]
@@ -660,7 +660,7 @@ class DebianGenerator(BloomGenerator):
         key_to_packages_which_depends_on = collections.defaultdict(list)
         keys_to_ignore = set()
         for package in self.packages.values():
-            package.evaluate_conditions(package_conditional_context(ros_distro))
+            evaluate_package_conditions(package, ros_distro)
             depends = [
                 dep for dep in (package.run_depends + package.buildtool_export_depends)
                 if dep.evaluated_condition]

--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -60,7 +60,7 @@ from bloom.generators import update_rosdep
 
 from bloom.generators.common import default_fallback_resolver
 from bloom.generators.common import invalidate_view_cache
-from bloom.generators.common import package_conditional_context
+from bloom.generators.common import evaluate_package_conditions
 from bloom.generators.common import resolve_rosdep_key
 
 from bloom.git import inbranch
@@ -232,7 +232,7 @@ def generate_substitutions_from_package(
     # Installation prefix
     data['InstallationPrefix'] = installation_prefix
     # Resolve dependencies
-    package.evaluate_conditions(package_conditional_context(ros_distro))
+    evaluate_package_conditions(package, ros_distro)
     depends = [
         dep for dep in (package.run_depends + package.buildtool_export_depends)
         if dep.evaluated_condition]
@@ -539,7 +539,7 @@ class RpmGenerator(BloomGenerator):
         key_to_packages_which_depends_on = collections.defaultdict(list)
         keys_to_ignore = set()
         for package in self.packages.values():
-            package.evaluate_conditions(package_conditional_context(rosdistro))
+            evaluate_package_conditions(package, rosdistro)
             depends = [
                 dep for dep in (package.run_depends + package.buildtool_export_depends)
                 if dep.evaluated_condition]

--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -235,13 +235,13 @@ def generate_substitutions_from_package(
     evaluate_package_conditions(package, ros_distro)
     depends = [
         dep for dep in (package.run_depends + package.buildtool_export_depends)
-        if dep.evaluated_condition]
+        if dep.evaluated_condition is not False]
     build_depends = [
         dep for dep in (package.build_depends + package.buildtool_depends + package.test_depends)
-        if dep.evaluated_condition]
+        if dep.evaluated_condition is not False]
     unresolved_keys = [
         dep for dep in (depends + build_depends + package.replaces + package.conflicts)
-        if dep.evaluated_condition]
+        if dep.evaluated_condition is not False]
     # The installer key is not considered here, but it is checked when the keys are checked before this
     resolved_deps = resolve_dependencies(unresolved_keys, os_name,
                                          os_version, ros_distro,
@@ -542,16 +542,16 @@ class RpmGenerator(BloomGenerator):
             evaluate_package_conditions(package, rosdistro)
             depends = [
                 dep for dep in (package.run_depends + package.buildtool_export_depends)
-                if dep.evaluated_condition]
+                if dep.evaluated_condition is not False]
             build_depends = [
                 dep for dep in (package.build_depends + package.buildtool_depends + package.test_depends)
-                if dep.evaluated_condition]
+                if dep.evaluated_condition is not False]
             unresolved_keys = [
                 dep for dep in (depends + build_depends + package.replaces + package.conflicts)
-                if dep.evaluated_condition]
+                if dep.evaluated_condition is not False]
             keys_to_ignore = {
                 dep for dep in keys_to_ignore.union(package.replaces + package.conflicts)
-                if dep.evaluated_condition}
+                if dep.evaluated_condition is not False}
             keys = [d.name for d in unresolved_keys]
             keys_to_resolve.extend(keys)
             for key in keys:


### PR DESCRIPTION
Closes #536 with some improved error messaging and behavior.

1. In order to release packages with format 3 package.xml files, a v4 rosdistro index is required to provide sufficient context for evaluating package conditions.
To make it clearer that the problem is the index version and not an invalid / unknown distribution_type, an explicit version check and dedicated error message has been added.

2. For package formats 1 and 2 conditions are evaluated with an empty context so that downstream code will correctly see all fields without conditions as True.