### PR TITLE
use shallow clone for rosdistro repository

### DIFF
--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -740,7 +740,7 @@ Increasing version of package(s) in repository `{repository}` to `{version}`:
                     warning("Skipping the pull request...")
                     return
                 _my_run('git checkout -b {new_branch}'.format(**locals()))
-                _my_run("git pull --depth 1 {rosdistro_url} {base_info[branch]}".format(**locals()),
+                _my_run("git pull --depth 10 {rosdistro_url} {base_info[branch]}".format(**locals()),
                         "Pulling latest rosdistro branch")
                 rosdistro_index_commit = get_rosdistro_index_commit()
                 if rosdistro_index_commit is not None:

--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -740,7 +740,7 @@ Increasing version of package(s) in repository `{repository}` to `{version}`:
                     warning("Skipping the pull request...")
                     return
                 _my_run('git checkout -b {new_branch}'.format(**locals()))
-                _my_run("git pull {rosdistro_url} {base_info[branch]}".format(**locals()),
+                _my_run("git pull --depth 1 {rosdistro_url} {base_info[branch]}".format(**locals()),
                         "Pulling latest rosdistro branch")
                 rosdistro_index_commit = get_rosdistro_index_commit()
                 if rosdistro_index_commit is not None:


### PR DESCRIPTION
This implements a 5-year old feature request, i.e. #259, to checkout the `rosdistro` repo in a shallow fashion. As the `rosdistro` repo incrementally grows, this feature become increasingly more important.