### PR TITLE
Always create archive of sources when building RPM

### DIFF
--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -781,8 +781,10 @@ class RpmGenerator(BloomGenerator):
         template_files = process_template_files('.', subs)
         # Remove any residual template files
         execute_command('git rm -rf ' + ' '.join("'{}'".format(t) for t in template_files))
-        # Add changes to the rpm folder
-        execute_command('git add ' + rpm_dir)
+        # Add marker file to tell mock to archive the sources
+        open('.write_tar', 'a').close()
+        # Add marker file changes to the rpm folder
+        execute_command('git add .write_tar ' + rpm_dir)
         # Commit changes
         execute_command('git commit -m "Generated RPM files for ' +
                         rpm_distro + '"')


### PR DESCRIPTION
The SCM plugin for mock will create an archive of the sources if either this marker file is present in the root of the project or the `write_tar` option is specified in mock's configuration.

The way bloom works, we always want to archive the sources, but this isn't the default configuration of the SCM plugin. Writing this marker file means one less configuration is necessary when consuming the
release repo to build the RPMs with mock.

More info: https://fedoraproject.org/wiki/Projects/Mock/Plugin/Scm#Tar_file