### PR TITLE
Update suites to remove those older than xenial and add new ones.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -4,5 +4,5 @@ Depends3: python3-yaml, python3-empy, python3-rosdep (>= 0.15.0), python3-rosdis
 Conflicts: python3-bloom
 Conflicts3: python-bloom
 Copyright-File: LICENSE.txt
-Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic jessie stretch buster
+Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
 X-Python3-Version: >= 3.4


### PR DESCRIPTION
Specifically removes Trusty, Utopic, Vivid, and Wily and adds Cosmic, Disco, and Eoan.