### PR TITLE
Split the --new-track and --edit-track options

### DIFF
--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -850,7 +850,7 @@ Versions of tools used:
 
 
 def _perform_release(
-    repository, track, distro, new_track, interactive, pretend, tracks_dict,
+    repository, track, distro, interactive, pretend, tracks_dict,
     override_release_repository_url, override_release_repository_push_url
 ):
     # Import here to allow lazy evaluation of commands/git/__init__.py
@@ -1021,7 +1021,7 @@ def check_for_patches_and_ignores(release_repo_path):
 
 
 def perform_release(
-    repository, track, distro, new_track, interactive, pretend, pull_request_only,
+    repository, track, distro, track_action, interactive, pretend, pull_request_only,
     override_release_repository_url, override_release_repository_push_url
 ):
     # Import here to allow lazy evaluation of commands/git/__init__.py
@@ -1041,7 +1041,7 @@ def perform_release(
             # Convert to a track
             info("Old bloom.conf file detected.")
             info(fmt("@{gf}@!==> @|Converting to bloom.conf to track"))
-            convert_old_bloom_conf(None if new_track else distro)
+            convert_old_bloom_conf(None if track_action == 'new' else distro)
         upconvert_bloom_to_config_branch()
         # Check that the track is valid
         tracks_dict = get_tracks_dict_raw()
@@ -1049,32 +1049,31 @@ def perform_release(
         def create_a_new_track(track, tracks_dict):
             if not track:
                 error("You must specify a track when creating a new one.", exit=True)
+            # Create a new track called <track>,
+            # copying an existing track if possible,
+            # and overriding the ros_distro
+            warning("Creating track '{0}'...".format(track))
+            overrides = {'ros_distro': distro}
+            if override_release_repository_push_url is not None:
+                overrides['release_repo_url'] = override_release_repository_push_url
+            new_track_cmd(track, copy_track='', overrides=overrides)
+            tracks_dict = get_tracks_dict_raw()
+            check_for_patches_and_ignores(release_repo.get_path())
+            return tracks_dict
+        # If new_track, create the new track first
+        if track_action == 'new':
+            tracks_dict = create_a_new_track(track, tracks_dict)
+        elif track_action == 'edit':
+            if not track:
+                error("You must specify a track when creating a new one.", exit=True)
             if track in tracks_dict['tracks']:
                 warning("Track '{0}' exists, editing...".format(track))
                 edit_track_cmd(track)
                 tracks_dict = get_tracks_dict_raw()
-            else:
-                # Create a new track called <track>,
-                # copying an existing track if possible,
-                # and overriding the ros_distro
-                warning("Creating track '{0}'...".format(track))
-                overrides = {'ros_distro': distro}
-                if override_release_repository_push_url is not None:
-                    overrides['release_repo_url'] = override_release_repository_push_url
-                new_track_cmd(track, copy_track='', overrides=overrides)
-                tracks_dict = get_tracks_dict_raw()
-                check_for_patches_and_ignores(release_repo.get_path())
-            return tracks_dict
-        # If new_track, create the new track first
-        if new_track:
-            tracks_dict = create_a_new_track(track, tracks_dict)
         if track and track not in tracks_dict['tracks']:
             error("Given track '{0}' does not exist in release repository."
                   .format(track))
             info("Available tracks: " + str(tracks_dict['tracks'].keys()))
-            if not track:
-                error("Cannot offer to make a new track, since a track name was not provided.",
-                      exit=True)
             if not maybe_continue(msg="Create a new track called '{0}' now".format(track)):
                 error("User quit.", exit=True)
             tracks_dict = create_a_new_track(track, tracks_dict)
@@ -1107,7 +1106,7 @@ def perform_release(
         start_summary(track)
         if not pull_request_only:
             _perform_release(
-                repository, track, distro, new_track, interactive, pretend, tracks_dict,
+                repository, track, distro, interactive, pretend, tracks_dict,
                 override_release_repository_url, override_release_repository_push_url
             )
         # Propose github pull request
@@ -1173,6 +1172,12 @@ def main(sysargs=None):
 
     if args.new_track and args.edit_track:
         error("Cannot both create a new track and edit an existing track", exit=True)
+    elif args.new_track:
+        track_action = 'new'
+    elif args.edit_track:
+        track_action = 'edit'
+    else:
+        track_action = 'none'
 
     if args.list_tracks:
         list_tracks(args.repository, args.ros_distro, args.override_release_repository_url)
@@ -1186,7 +1191,7 @@ def main(sysargs=None):
         disable_git_clone(True)
         quiet_git_clone_warning(True)
         perform_release(args.repository, args.track, args.ros_distro,
-                        args.new_track or args.edit_track, not args.non_interactive, args.pretend,
+                        args.track_action, not args.non_interactive, args.pretend,
                         args.pull_request_only,
                         args.override_release_repository_url,
                         args.override_release_repository_push_url)


### PR DESCRIPTION
While using `bloom-release`, I noticed that `--new-track` and `--edit-track` were in the same help bullet.  They both use exactly the same code path, so from an implementation point of view, that makes some sense.  However, they are conceptually different things, so I think splitting the help makes sense.  That's what commit e3beb8861698bc8e63e7882c719f1313e429f40e .

Commit 34c07a151ef2866bcfc740d5656a133384c4e6e4 starts to go further and make them actually different actions.  It doesn't quite work yet, but I was shooting for the following behavior:

1.  `--new-track` and `--edit-track` are mutually exclusive options
1.  If `--new-track` is specified, and the track already exists, an error is thrown.
1.  If `--edit-track` is specified, and the track does not exist, an error is thrown.
1.  If neither is specified, and the track doesn't exist, create the new track.

However, there are a lot of use-cases here, so I'm not sure if that logic is what we are going for.  I'm opening this as a draft until then to get some feedback and see what others think of this.