### PR TITLE
Support for BLOOM_NO_ROSDISTRO_PULL_REQUEST environment variable

### DIFF
--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -1110,26 +1110,27 @@ def perform_release(
                 repository, track, distro, new_track, interactive, pretend, tracks_dict,
                 override_release_repository_url, override_release_repository_push_url
             )
-        # Propose github pull request
-        info(fmt("@{gf}@!==> @|") +
-             "Generating pull request to distro file located at '{0}'"
-             .format(get_distribution_file_url(distro)))
-        try:
-            pull_request_url = open_pull_request(
-                track, repository, distro, interactive, override_release_repository_url
-            )
-            if pull_request_url:
-                info(fmt(_success) + "Pull request opened at: {0}".format(pull_request_url))
-                if 'BLOOM_NO_WEBBROWSER' not in os.environ and platform.system() in ['Darwin']:
-                    webbrowser.open(pull_request_url)
-            else:
-                info("The release of your packages was successful, but the pull request failed.")
-                info("Please manually open a pull request by editing the file here: '{0}'"
-                     .format(get_distribution_file_url(distro)))
-                info(fmt(_error) + "No pull request opened.")
-        except Exception as e:
-            debug(traceback.format_exc())
-            error("Failed to open pull request: {0} - {1}".format(type(e).__name__, e), exit=True)
+        if 'BLOOM_NO_ROSDISTRO_PULL_REQUEST' not in os.environ:
+            # Propose github pull request
+            info(fmt("@{gf}@!==> @|") +
+                 "Generating pull request to distro file located at '{0}'"
+                 .format(get_distribution_file_url(distro)))
+            try:
+                pull_request_url = open_pull_request(
+                    track, repository, distro, interactive, override_release_repository_url
+                )
+                if pull_request_url:
+                    info(fmt(_success) + "Pull request opened at: {0}".format(pull_request_url))
+                    if 'BLOOM_NO_WEBBROWSER' not in os.environ and platform.system() in ['Darwin']:
+                        webbrowser.open(pull_request_url)
+                else:
+                    info("The release of your packages was successful, but the pull request failed.")
+                    info("Please manually open a pull request by editing the file here: '{0}'"
+                         .format(get_distribution_file_url(distro)))
+                    info(fmt(_error) + "No pull request opened.")
+            except Exception as e:
+                debug(traceback.format_exc())
+                error("Failed to open pull request: {0} - {1}".format(type(e).__name__, e), exit=True)
 
 
 def get_argument_parser():

--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -1147,6 +1147,8 @@ def get_argument_parser():
         help="if used, a new track will be created before running bloom")
     add('--pretend', '-s', default=False, action='store_true',
         help="Pretends to push and release")
+    add('--no-pull-request', default=False, action='store_true',
+        help="Prevents a pull request from being opened after release")
     add('--no-web', default=False, action='store_true',
         help="prevents a web browser from being opened at the end")
     add('--pull-request-only', '-p', default=False, action='store_true',
@@ -1173,6 +1175,9 @@ def main(sysargs=None):
     if args.list_tracks:
         list_tracks(args.repository, args.ros_distro, args.override_release_repository_url)
         return
+
+    if args.no_pull_request:
+        os.environ['BLOOM_NO_ROSDISTRO_PULL_REQUEST'] = '1'
 
     if args.no_web:
         os.environ['BLOOM_NO_WEBBROWSER'] = '1'


### PR DESCRIPTION
The goal of the variable is to avoid the steps of generating and pushing the PR with changes to rosdistro.

Not usual for catkin packages but we have use cases where we use bloom to generate the metadata and use `build.osrfoundation.org` to build packages that can not go into rosdistro index.