### PR TITLE
debian: remove any python bytecode from package (#544)

### DIFF
--- a/bloom/generators/debian/templates/ament_cmake/rules.em
+++ b/bloom/generators/debian/templates/ament_cmake/rules.em
@@ -58,3 +58,4 @@ override_dh_auto_install:
 	# set things like CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
 	dh_auto_install
+	find $(DESTDIR) -name '*.py[co]' -delete

--- a/bloom/generators/debian/templates/ament_python/rules.em
+++ b/bloom/generators/debian/templates/ament_python/rules.em
@@ -61,3 +61,4 @@ override_dh_auto_install:
 	# set things like CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
 	dh_auto_install
+	find $(DESTDIR) -name '*.py[co]' -delete

--- a/bloom/generators/debian/templates/catkin/rules.em
+++ b/bloom/generators/debian/templates/catkin/rules.em
@@ -59,3 +59,4 @@ override_dh_auto_install:
 	# set things like CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
 	dh_auto_install
+	find $(DESTDIR) -name '*.py[co]' -delete

--- a/bloom/generators/debian/templates/cmake/rules.em
+++ b/bloom/generators/debian/templates/cmake/rules.em
@@ -56,3 +56,4 @@ override_dh_auto_install:
 	# set things like CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
 	dh_auto_install
+	find $(DESTDIR) -name '*.py[co]' -delete


### PR DESCRIPTION
In freshly-generated bloom templates for Debian, clean out any compiled Python bytecode that might have been installed. This is handled by a `find` following the `dh_auto_install`, so we still get the benefits of e.g. syntax checking that come with compiling the python.

This also ought resolve #199 from 2013 or so, and eliminate the lintian error `package-installs-python-bytecode` (https://lintian.debian.org/tags/package-installs-python-bytecode.html).