### PR TITLE
Add ROS_PYTHON_VERSION to dependency conditionals.

### DIFF
--- a/bloom/generators/common.py
+++ b/bloom/generators/common.py
@@ -141,7 +141,12 @@ def package_conditional_context(ros_distro):
         error("Bloom cannot cope with distribution_type '{0}'".format(
             distribution_type), exit=True)
     python_version = get_python_version(ros_distro)
-    if python_version == 2:
+    if python_version is None:
+        error(
+            'No python_version found in the rosdistro index. '
+            'The rosdistro index must include this key for bloom to work correctly.',
+            exit=True)
+    elif python_version == 2:
         ros_python_version = '2'
     elif python_version == 3:
         ros_python_version = '3'

--- a/bloom/generators/common.py
+++ b/bloom/generators/common.py
@@ -42,6 +42,7 @@ from bloom.logging import info
 
 from bloom.rosdistro_api import get_distribution_type
 from bloom.rosdistro_api import get_index
+from bloom.rosdistro_api import get_python_version
 
 from bloom.util import code
 from bloom.util import maybe_continue
@@ -139,9 +140,19 @@ def package_conditional_context(ros_distro):
     else:
         error("Bloom cannot cope with distribution_type '{0}'".format(
             distribution_type), exit=True)
+    python_version = get_python_version(ros_distro)
+    if python_version == 2:
+        ros_python_version = '2'
+    elif python_version == 3:
+        ros_python_version = '3'
+    else:
+        error("Bloom cannot cope with python_version '{0}'".format(
+            python_version), exit=True)
+
     return {
             'ROS_VERSION': ros_version,
             'ROS_DISTRO': ros_distro,
+            'ROS_PYTHON_VERSION': ros_python_version,
             }
 
 

--- a/bloom/rosdistro_api.py
+++ b/bloom/rosdistro_api.py
@@ -136,6 +136,7 @@ def list_distributions():
 def get_distribution_type(distro):
     return get_index().distributions[distro].get('distribution_type')
 
+
 def get_python_version(distro):
     return get_index().distributions[distro].get('python_version')
 

--- a/bloom/rosdistro_api.py
+++ b/bloom/rosdistro_api.py
@@ -136,6 +136,9 @@ def list_distributions():
 def get_distribution_type(distro):
     return get_index().distributions[distro].get('distribution_type')
 
+def get_python_version(distro):
+    return get_index().distributions[distro].get('python_version')
+
 
 def get_most_recent(thing_name, repository, reference_distro):
     reference_distro_type = get_distribution_type(reference_distro)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
     'python-dateutil',
     'PyYAML',
     'rosdep >= 0.15.0',
-    'rosdistro >= 0.7.0',
+    'rosdistro >= 0.7.5',
     'vcstools >= 0.1.22',
 ]
 

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
-Depends: python-yaml, python-empy, python-argparse, python-rosdep (>= 0.15.0), python-rosdistro (>= 0.7.0), python-vcstools (>= 0.1.22), python-setuptools, python-catkin-pkg (>= 0.4.3)
-Depends3: python3-yaml, python3-empy, python3-rosdep (>= 0.15.0), python3-rosdistro (>= 0.7.0), python3-vcstools (>= 0.1.22), python3-setuptools, python3-catkin-pkg (>= 0.4.3)
+Depends: python-yaml, python-empy, python-argparse, python-rosdep (>= 0.15.0), python-rosdistro (>= 0.7.5), python-vcstools (>= 0.1.22), python-setuptools, python-catkin-pkg (>= 0.4.3)
+Depends3: python3-yaml, python3-empy, python3-rosdep (>= 0.15.0), python3-rosdistro (>= 0.7.5), python3-vcstools (>= 0.1.22), python3-setuptools, python3-catkin-pkg (>= 0.4.3)
 Conflicts: python3-bloom
 Conflicts3: python-bloom
 Copyright-File: LICENSE.txt


### PR DESCRIPTION
The ROS_PYTHON_VERSION conditional is referenced in [REP-149](https://www.ros.org/reps/rep-0149.html) as a standard mechanism for determining the python major version used within a ROS workspace. For most ROS tools, package conditions can be taken from the local environment but Bloom has a different role: generating platform specific release information from a developer's workstation which may not match the targeted platforms. As with #519, bloom does not take package conditions from the local environment but instead from the distribution configuration. To support this both here and in other tools, [REP-153](https://www.ros.org/reps/rep-0153.html) was amended (see https://github.com/ros-infrastructure/rep/pull/207) to include a `python_version` field in the distribution information. Bloom now uses this to provide ROS_PYTHON_VERSION as a package condition.

Support for arbitrary package conditions is not introduced in this PR. Some discussion has been made of embedding a dict of conditions into the tracks.yaml file bloom uses to configure release tracks but some refactoring is required to wire that through and I'd rather wait until we have #539 merged to take that on.