### PR TITLE
Escape '@' symbol if present in version tag

### DIFF
--- a/bloom/commands/git/import_upstream.py
+++ b/bloom/commands/git/import_upstream.py
@@ -85,7 +85,7 @@ def version_check(version):
         return
     last_tag_version = last_tag.split('/')[-1]
     info(fmt("The latest upstream tag in the release repository is '@!{0}@|'."
-         .format(last_tag)))
+         .format(last_tag.replace('@', '@@'))))
     # Ensure the new version is greater than the last tag
     if parse_version(version) < parse_version(last_tag_version):
         warning("""\

--- a/test/system_tests/test_catkin_release.py
+++ b/test/system_tests/test_catkin_release.py
@@ -362,3 +362,27 @@ def test_multi_package_repository(directory=None):
                     with open('debian/copyright', 'r') as f:
                         assert pkg + ' license' in f.read(), \
                             "debian/copyright does not include right license text"
+
+@in_temporary_directory
+def test_upstream_tag_special_tag(directory=None):
+    """
+    Release a single package catkin (melodic) repository, but ensure
+    """
+    directory = directory if directory is not None else os.getcwd()
+    # Setup
+    upstream_dir = create_upstream_repository(['foo'], directory)
+    upstream_url = 'file://' + upstream_dir
+    release_url = create_release_repo(
+        upstream_url,
+        'git',
+        'melodic_devel',
+        'melodic')
+    release_dir = os.path.join(directory, 'foo_release_clone')
+    release_client = get_vcs_client('git', release_dir)
+    assert release_client.checkout(release_url)
+
+    with change_directory(release_dir):
+        user('git tag upstream/0.0.0@baz')
+
+    import bloom.commands.git.release
+    _test_unary_package_repository(release_dir, '0.1.0', directory)

--- a/test/system_tests/test_catkin_release.py
+++ b/test/system_tests/test_catkin_release.py
@@ -366,7 +366,9 @@ def test_multi_package_repository(directory=None):
 @in_temporary_directory
 def test_upstream_tag_special_tag(directory=None):
     """
-    Release a single package catkin (melodic) repository, but ensure
+    Release a single package catkin (melodic) repository, first put
+    an upstream tag into the release repository to test that bloom
+    can handle it.
     """
     directory = directory if directory is not None else os.getcwd()
     # Setup


### PR DESCRIPTION
Avoids backtraces like the following that occur when there is an '@' symbol in the previously released `upstream/:{version}` value.
```
git-bloom-import-upstream /tmp/tmpc250f3nv/upstream-0.0.8@baz.tar.gz  --release-version 0.0.10@baz --replace
+++ Cloning working copy for safety
Traceback (most recent call last):
  File "git-bloom-import-upstream", line 11, in <module>
    load_entry_point('bloom', 'console_scripts', 'git-bloom-import-upstream')()
  File "bloom/commands/git/import_upstream.py", line 398, in main
    args.replace)
  File "bloom/commands/git/import_upstream.py", line 291, in import_upstream
    version_check(version)
  File "bloom/commands/git/import_upstream.py", line 88, in version_check
    .format(last_tag)))
  File "bloom/logging.py", line 356, in fmt
    msg = t.substitute(_ansi) + ansi('reset')
  File "/usr/lib64/python3.7/string.py", line 132, in substitute
    return self.pattern.sub(convert, self.template)
  File "/usr/lib64/python3.7/string.py", line 125, in convert
    return str(mapping[named])
KeyError: 'baz'
```

This is a fringe case to be sure, but I hit it when dealing with a second release of some of our snapshot releases.