### PR TITLE
Also run tests with Python 3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
   - "2.7"
   - "3.4"
   - "3.6"
+  - "3.7"
+  - "3.8"
 # command to install dependencies
 install:
   - pip install PyYAML argparse rosdep vcstools catkin-pkg python-dateutil setuptools


### PR DESCRIPTION
Debian Buster uses Python 3.7 and Ubuntu Focal will use Python 3.8