### PR TITLE
Depend on rosdistro 0.8.0 to solve problems with test_abi key

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
     'python-dateutil',
     'PyYAML',
     'rosdep >= 0.15.0',
-    'rosdistro >= 0.7.5',
+    'rosdistro >= 0.8.0',
     'vcstools >= 0.1.22',
 ]
 

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
-Depends: python-yaml, python-empy, python-argparse, python-rosdep (>= 0.15.0), python-rosdistro (>= 0.7.5), python-vcstools (>= 0.1.22), python-setuptools, python-catkin-pkg (>= 0.4.3)
-Depends3: python3-yaml, python3-empy, python3-rosdep (>= 0.15.0), python3-rosdistro (>= 0.7.5), python3-vcstools (>= 0.1.22), python3-setuptools, python3-catkin-pkg (>= 0.4.3)
+Depends: python-yaml, python-empy, python-argparse, python-rosdep (>= 0.15.0), python-rosdistro (>= 0.8.0), python-vcstools (>= 0.1.22), python-setuptools, python-catkin-pkg (>= 0.4.3)
+Depends3: python3-yaml, python3-empy, python3-rosdep (>= 0.15.0), python3-rosdistro (>= 0.8.0), python3-vcstools (>= 0.1.22), python3-setuptools, python3-catkin-pkg (>= 0.4.3)
 Conflicts: python3-bloom
 Conflicts3: python-bloom
 Copyright-File: LICENSE.txt


### PR DESCRIPTION
[Some](https://answers.ros.org/question/341427) [users](#issuecomment-573302415) reported problems with bloom after the introduction of the `test_abi` key in https://github.com/ros-infrastructure/rosdistro/pull/147. In order to be sure that upgrades of bloom use the correct rosdistro, this PR changes dependencies to pull the `0.8.0` version which implements the `test_abi` parsing.

After merging we probably need to create a new release of bloom.

