### PR TITLE
Provide -devel, -doc and -runtime virtual packages in RPM

### DIFF
--- a/bloom/generators/rosrpm.py
+++ b/bloom/generators/rosrpm.py
@@ -149,11 +149,8 @@ def get_subs(pkg, os_name, os_version, ros_distro):
     )
     subs['Package'] = rosify_package_name(subs['Package'], ros_distro)
     subs['Provides'] += [
-        subs['Package'] + '-devel',
-        subs['Package'] + '-doc',
-        subs['Package'] + '-runtime',
-    ]
-    return subs
+        '%%{name}-%s' % subpackage for subpackage in [
+            'devel', 'doc', 'runtime']]
 
 
 def main(args=None):

--- a/bloom/generators/rosrpm.py
+++ b/bloom/generators/rosrpm.py
@@ -149,7 +149,7 @@ def get_subs(pkg, os_name, os_version, ros_distro):
     )
     subs['Package'] = rosify_package_name(subs['Package'], ros_distro)
     subs['Provides'] += [
-        '%%{name}-%s' % subpackage for subpackage in [
+        '%%{name}-%s = %%{version}-%%{release}' % subpackage for subpackage in [
             'devel', 'doc', 'runtime']]
 
 

--- a/bloom/generators/rosrpm.py
+++ b/bloom/generators/rosrpm.py
@@ -151,6 +151,7 @@ def get_subs(pkg, os_name, os_version, ros_distro):
     subs['Provides'] += [
         '%%{name}-%s = %%{version}-%%{release}' % subpackage for subpackage in [
             'devel', 'doc', 'runtime']]
+    return subs
 
 
 def main(args=None):

--- a/bloom/generators/rosrpm.py
+++ b/bloom/generators/rosrpm.py
@@ -89,6 +89,11 @@ class RosRpmGenerator(RpmGenerator):
         )
         subs['Package'] = rosify_package_name(subs['Package'], self.rosdistro)
 
+        # Virtual packages
+        subs['Provides'] += [
+            '%%{name}-%s = %%{version}-%%{release}' % subpackage for subpackage in [
+                'devel', 'doc', 'runtime']]
+
         # ROS 2 specific bloom extensions.
         ros2_distros = [
             name for name, values in get_index().distributions.items()
@@ -148,9 +153,6 @@ def get_subs(pkg, os_name, os_version, ros_distro):
         ros_distro
     )
     subs['Package'] = rosify_package_name(subs['Package'], ros_distro)
-    subs['Provides'] += [
-        '%%{name}-%s = %%{version}-%%{release}' % subpackage for subpackage in [
-            'devel', 'doc', 'runtime']]
     return subs
 
 

--- a/bloom/generators/rosrpm.py
+++ b/bloom/generators/rosrpm.py
@@ -148,6 +148,11 @@ def get_subs(pkg, os_name, os_version, ros_distro):
         ros_distro
     )
     subs['Package'] = rosify_package_name(subs['Package'], ros_distro)
+    subs['Provides'] += [
+        subs['Package'] + '-devel',
+        subs['Package'] + '-doc',
+        subs['Package'] + '-runtime',
+    ]
     return subs
 
 

--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -259,6 +259,7 @@ def generate_substitutions_from_package(
     data['Conflicts'] = sorted(
         set(format_depends(package.conflicts, resolved_deps))
     )
+    data['Provides'] = []
 
     # Build-type specific substitutions.
     build_type = package.get_build_type()

--- a/bloom/generators/rpm/templates/ament_cmake/template.spec.em
+++ b/bloom/generators/rpm/templates/ament_cmake/template.spec.em
@@ -10,7 +10,7 @@ Summary:        ROS @(Name) package
 License:        @(License)
 @[if Homepage and Homepage != '']URL:            @(Homepage)@\n@[end if]Source0:        %{name}-%{version}.tar.gz
 @[if NoArch]@\nBuildArch:      noarch@\n@[end if]
-@[for p in Depends]Requires:       @p@\n@[end for]@[for p in BuildDepends]BuildRequires:  @p@\n@[end for]@[for p in Conflicts]Conflicts:      @p@\n@[end for]@[for p in Replaces]Obsoletes:      @p@\n@[end for]
+@[for p in Depends]Requires:       @p@\n@[end for]@[for p in BuildDepends]BuildRequires:  @p@\n@[end for]@[for p in Conflicts]Conflicts:      @p@\n@[end for]@[for p in Replaces]Obsoletes:      @p@\n@[end for]@[for p in Provides]Provides:       @p@\n@[end for]
 %description
 @(Description)
 

--- a/bloom/generators/rpm/templates/ament_python/template.spec.em
+++ b/bloom/generators/rpm/templates/ament_python/template.spec.em
@@ -10,7 +10,7 @@ Summary:        ROS @(Name) package
 License:        @(License)
 @[if Homepage and Homepage != '']URL:            @(Homepage)@\n@[end if]Source0:        %{name}-%{version}.tar.gz
 @[if NoArch]@\nBuildArch:      noarch@\n@[end if]
-@[for p in Depends]Requires:       @p@\n@[end for]@[for p in sorted(BuildDepends + ['python%{python3_pkgversion}-devel'])]BuildRequires:  @p@\n@[end for]@[for p in Conflicts]Conflicts:      @p@\n@[end for]@[for p in Replaces]Obsoletes:      @p@\n@[end for]
+@[for p in Depends]Requires:       @p@\n@[end for]@[for p in sorted(BuildDepends + ['python%{python3_pkgversion}-devel'])]BuildRequires:  @p@\n@[end for]@[for p in Conflicts]Conflicts:      @p@\n@[end for]@[for p in Replaces]Obsoletes:      @p@\n@[end for]@[for p in Provides]Provides:       @p@\n@[end for]
 %description
 @(Description)
 

--- a/bloom/generators/rpm/templates/catkin/template.spec.em
+++ b/bloom/generators/rpm/templates/catkin/template.spec.em
@@ -10,7 +10,7 @@ Summary:        ROS @(Name) package
 License:        @(License)
 @[if Homepage and Homepage != '']URL:            @(Homepage)@\n@[end if]Source0:        %{name}-%{version}.tar.gz
 @[if NoArch]@\nBuildArch:      noarch@\n@[end if]
-@[for p in Depends]Requires:       @p@\n@[end for]@[for p in BuildDepends]BuildRequires:  @p@\n@[end for]@[for p in Conflicts]Conflicts:      @p@\n@[end for]@[for p in Replaces]Obsoletes:      @p@\n@[end for]
+@[for p in Depends]Requires:       @p@\n@[end for]@[for p in BuildDepends]BuildRequires:  @p@\n@[end for]@[for p in Conflicts]Conflicts:      @p@\n@[end for]@[for p in Replaces]Obsoletes:      @p@\n@[end for]@[for p in Provides]Provides:       @p@\n@[end for]
 %description
 @(Description)
 

--- a/bloom/generators/rpm/templates/cmake/template.spec.em
+++ b/bloom/generators/rpm/templates/cmake/template.spec.em
@@ -10,7 +10,7 @@ Summary:        ROS @(Name) package
 License:        @(License)
 @[if Homepage and Homepage != '']URL:            @(Homepage)@\n@[end if]Source0:        %{name}-%{version}.tar.gz
 @[if NoArch]@\nBuildArch:      noarch@\n@[end if]
-@[for p in Depends]Requires:       @p@\n@[end for]@[for p in BuildDepends]BuildRequires:  @p@\n@[end for]@[for p in Conflicts]Conflicts:      @p@\n@[end for]@[for p in Replaces]Obsoletes:      @p@\n@[end for]
+@[for p in Depends]Requires:       @p@\n@[end for]@[for p in BuildDepends]BuildRequires:  @p@\n@[end for]@[for p in Conflicts]Conflicts:      @p@\n@[end for]@[for p in Replaces]Obsoletes:      @p@\n@[end for]@[for p in Provides]Provides:       @p@\n@[end for]
 %description
 @(Description)
 


### PR DESCRIPTION
There is nothing that will currently take advantage of these virtual packages, but providing them now would allow us to implement a mechanism to take advantage of them in the future without re-blooming everything.

The virtual packages which an RPM package provides are not generally exposed in any package lists, so this shouldn't cause any confusion to end users. If merged, you could view this as a "present but disabled" feature.

The motivations for making this change right now, despite being incomplete, are:
* It could save us from requiring re-blooming later on
* It could be used to test a more complete solution at-scale
* It does not change the existing behavior of the packages at all
* Since the functionality described by these virtual packages are, in practice, provided by the monolithic package we're currently creating, these virtual packages are not incorrect. This pattern is often used and sometimes even required in Fedora packaging, such as providing `-static` on a package which contains both headers and static (`*.a`) libraries.