### PR TITLE
Provide group membership information in RPM packages

### DIFF
--- a/bloom/generators/rosrpm.py
+++ b/bloom/generators/rosrpm.py
@@ -94,6 +94,16 @@ class RosRpmGenerator(RpmGenerator):
             '%%{name}-%s = %%{version}-%%{release}' % subpackage for subpackage in [
                 'devel', 'doc', 'runtime']]
 
+        # Group membership
+        subs['Provides'].extend(
+            sanitize_package_name(rosify_package_name(g.name, self.rosdistro)) +
+            '(member)' for g in package.member_of_groups)
+        if self.os_name != 'rhel' or not rpm_distro.isnumeric() or int(rpm_distro) >= 8:
+            # Weak dependencies are not supported in RHEL < 8 and will break the package.
+            subs['Supplements'].extend(
+                sanitize_package_name(rosify_package_name(g.name, self.rosdistro)) +
+                '(all)' for g in package.member_of_groups)
+
         # ROS 2 specific bloom extensions.
         ros2_distros = [
             name for name, values in get_index().distributions.items()

--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -260,6 +260,7 @@ def generate_substitutions_from_package(
         set(format_depends(package.conflicts, resolved_deps))
     )
     data['Provides'] = []
+    data['Supplements'] = []
 
     # Build-type specific substitutions.
     build_type = package.get_build_type()

--- a/bloom/generators/rpm/templates/ament_cmake/template.spec.em
+++ b/bloom/generators/rpm/templates/ament_cmake/template.spec.em
@@ -10,7 +10,7 @@ Summary:        ROS @(Name) package
 License:        @(License)
 @[if Homepage and Homepage != '']URL:            @(Homepage)@\n@[end if]Source0:        %{name}-%{version}.tar.gz
 @[if NoArch]@\nBuildArch:      noarch@\n@[end if]
-@[for p in Depends]Requires:       @p@\n@[end for]@[for p in BuildDepends]BuildRequires:  @p@\n@[end for]@[for p in Conflicts]Conflicts:      @p@\n@[end for]@[for p in Replaces]Obsoletes:      @p@\n@[end for]@[for p in Provides]Provides:       @p@\n@[end for]
+@[for p in Depends]Requires:       @p@\n@[end for]@[for p in BuildDepends]BuildRequires:  @p@\n@[end for]@[for p in Conflicts]Conflicts:      @p@\n@[end for]@[for p in Replaces]Obsoletes:      @p@\n@[end for]@[for p in Provides]Provides:       @p@\n@[end for]@[for p in Supplements]Supplements:    @p@\n@[end for]
 %description
 @(Description)
 

--- a/bloom/generators/rpm/templates/ament_python/template.spec.em
+++ b/bloom/generators/rpm/templates/ament_python/template.spec.em
@@ -10,7 +10,7 @@ Summary:        ROS @(Name) package
 License:        @(License)
 @[if Homepage and Homepage != '']URL:            @(Homepage)@\n@[end if]Source0:        %{name}-%{version}.tar.gz
 @[if NoArch]@\nBuildArch:      noarch@\n@[end if]
-@[for p in Depends]Requires:       @p@\n@[end for]@[for p in sorted(BuildDepends + ['python%{python3_pkgversion}-devel'])]BuildRequires:  @p@\n@[end for]@[for p in Conflicts]Conflicts:      @p@\n@[end for]@[for p in Replaces]Obsoletes:      @p@\n@[end for]@[for p in Provides]Provides:       @p@\n@[end for]
+@[for p in Depends]Requires:       @p@\n@[end for]@[for p in sorted(BuildDepends + ['python%{python3_pkgversion}-devel'])]BuildRequires:  @p@\n@[end for]@[for p in Conflicts]Conflicts:      @p@\n@[end for]@[for p in Replaces]Obsoletes:      @p@\n@[end for]@[for p in Provides]Provides:       @p@\n@[end for]@[for p in Supplements]Supplements:    @p@\n@[end for]
 %description
 @(Description)
 

--- a/bloom/generators/rpm/templates/catkin/template.spec.em
+++ b/bloom/generators/rpm/templates/catkin/template.spec.em
@@ -10,7 +10,7 @@ Summary:        ROS @(Name) package
 License:        @(License)
 @[if Homepage and Homepage != '']URL:            @(Homepage)@\n@[end if]Source0:        %{name}-%{version}.tar.gz
 @[if NoArch]@\nBuildArch:      noarch@\n@[end if]
-@[for p in Depends]Requires:       @p@\n@[end for]@[for p in BuildDepends]BuildRequires:  @p@\n@[end for]@[for p in Conflicts]Conflicts:      @p@\n@[end for]@[for p in Replaces]Obsoletes:      @p@\n@[end for]@[for p in Provides]Provides:       @p@\n@[end for]
+@[for p in Depends]Requires:       @p@\n@[end for]@[for p in BuildDepends]BuildRequires:  @p@\n@[end for]@[for p in Conflicts]Conflicts:      @p@\n@[end for]@[for p in Replaces]Obsoletes:      @p@\n@[end for]@[for p in Provides]Provides:       @p@\n@[end for]@[for p in Supplements]Supplements:    @p@\n@[end for]
 %description
 @(Description)
 

--- a/bloom/generators/rpm/templates/cmake/template.spec.em
+++ b/bloom/generators/rpm/templates/cmake/template.spec.em
@@ -10,7 +10,7 @@ Summary:        ROS @(Name) package
 License:        @(License)
 @[if Homepage and Homepage != '']URL:            @(Homepage)@\n@[end if]Source0:        %{name}-%{version}.tar.gz
 @[if NoArch]@\nBuildArch:      noarch@\n@[end if]
-@[for p in Depends]Requires:       @p@\n@[end for]@[for p in BuildDepends]BuildRequires:  @p@\n@[end for]@[for p in Conflicts]Conflicts:      @p@\n@[end for]@[for p in Replaces]Obsoletes:      @p@\n@[end for]@[for p in Provides]Provides:       @p@\n@[end for]
+@[for p in Depends]Requires:       @p@\n@[end for]@[for p in BuildDepends]BuildRequires:  @p@\n@[end for]@[for p in Conflicts]Conflicts:      @p@\n@[end for]@[for p in Replaces]Obsoletes:      @p@\n@[end for]@[for p in Provides]Provides:       @p@\n@[end for]@[for p in Supplements]Supplements:    @p@\n@[end for]
 %description
 @(Description)
 


### PR DESCRIPTION
This is not a complete implementation of group support in RPMS. The package.xml format does not currently contain enough information for us to specify the specifics of a group dependency. However, we do have enough information to express membership.

Nothing will automatically take advantage of this new group membership information right now, but it will open the door to a mechanism in the future without re-blooming all group members. If merged, you could view this as a "present but disabled" feature.

The motivations for making this change right now, despite being incomplete, are:
* It could save us from requiring re-blooming later on
* It could be used to simplify our existing ad-hoc patching in specific cases
* It could be used to test a more complete solution at-scale
* It does not change the existing behavior of the packages at all

We could also take advantage of this information in the manual patching we're currently doing to express dependencies on "one or more members" of a group.

This will change will manifest as follows:
Given a package foo that has `<member_of_group>bar</member_of_group>` package ros-rosdistro-foo will provide the virtual package "ros-distro-bar(member)".
If the target OS supports weak dependencies, the package will also declare a weak reverse-dependency on the virtual package "ros-distro-bar(all)". Since no packages provide "ros-distro-bar(all)" and no packages depend on "ros-distro-bar(member)" automatically, this functionality will be hidden unless specifically called-out or used.