### PR TITLE
Suppress automatic rosdep with BLOOM_SKIP_ROSDEP_UPDATE

### DIFF
--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -575,7 +575,7 @@ def sanitize_package_name(name):
 class DebianGenerator(BloomGenerator):
     title = 'debian'
     description = "Generates debians from the catkin meta data"
-    has_run_rosdep = False
+    has_run_rosdep = os.environ.get('BLOOM_SKIP_ROSDEP_UPDATE', '0').lower() not in ['0', 'f', 'false', 'n', 'no']
     default_install_prefix = '/usr'
     rosdistro = os.environ.get('ROS_DISTRO', 'indigo')
 

--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -446,7 +446,7 @@ def sanitize_package_name(name):
 class RpmGenerator(BloomGenerator):
     title = 'rpm'
     description = "Generates RPMs from the catkin meta data"
-    has_run_rosdep = False
+    has_run_rosdep = os.environ.get('BLOOM_SKIP_ROSDEP_UPDATE', '0').lower() not in ['0', 'f', 'false', 'n', 'no']
     default_install_prefix = '/usr'
     rosdistro = os.environ.get('ROS_DISTRO', 'indigo')
 


### PR DESCRIPTION
This off-by-default flag will suppress the automatic call to `rosdep update` at the beginning of each generator.

Note that answering 'y' to a rosdep resolution failure prompt will still trigger a call to `rosdep update`, this flag only suppresses the automatic one.