### PR TITLE
Drop Connext from RPM RMW list

### DIFF
--- a/bloom/generators/rosrpm.py
+++ b/bloom/generators/rosrpm.py
@@ -107,12 +107,9 @@ class RosRpmGenerator(RpmGenerator):
                     self.rosdistro not in ('r2b2', 'r2b3', 'ardent') and \
                     'rosidl_interface_packages' in [p.name for p in package.member_of_groups]:
                 ROS2_VENDOR_TYPESUPPORT_DEPENDENCIES = [
-                    'rmw-connext-cpp',
                     'rmw-fastrtps-cpp',
                     'rmw-implementation',
                     'rmw-opensplice-cpp',
-                    'rosidl-typesupport-connext-c',
-                    'rosidl-typesupport-connext-cpp',
                     'rosidl-typesupport-opensplice-c',
                     'rosidl-typesupport-opensplice-cpp',
                 ]


### PR DESCRIPTION
As it stands, RTI Connext is not available in an RPM package, so this dependency isn't applicable.