### PR TITLE
Resolve PyYAML Python 3.4 support in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ python:
   - "3.6"
 # command to install dependencies
 install:
-  - pip install PyYAML==5.2 # Forcing PyYAML 5.2 while we retain Python 3.4 support PyYAML 5.3 and higher does not support python 3.4
-  - pip install argparse rosdep vcstools catkin-pkg python-dateutil setuptools
+  - if [ $TRAVIS_PYTHON_VERSION == "3.4" ]; then pip install PyYAML==5.2; fi # Forcing PyYAML 5.2 while we retain Python 3.4 support PyYAML 5.3 and higher does not support python 3.4
+  - pip install PyYAML argparse rosdep vcstools catkin-pkg python-dateutil setuptools
   - pip install nose coverage pep8
   - git clone https://github.com/dirk-thomas/empy.git /tmp/empy
   - cd /tmp/empy

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
+  - "3.4"  # When support for 3.4 is removed unpin the PyYAML version below.
   - "3.6"
 # command to install dependencies
 install:
-  - pip install PyYAML argparse rosdep vcstools catkin-pkg python-dateutil setuptools
+  - pip install PyYAML==5.2 # Forcing PyYAML 5.2 while we retain Python 3.4 support PyYAML 5.3 and higher does not support python 3.4
+  - pip install argparse rosdep vcstools catkin-pkg python-dateutil setuptools
   - pip install nose coverage pep8
   - git clone https://github.com/dirk-thomas/empy.git /tmp/empy
   - cd /tmp/empy


### PR DESCRIPTION
CI is failing on python 3.4 because the new version of PyYAML dropped support.