### PR TITLE
Add an optional release version suffix to RPM templates

### DIFF
--- a/bloom/generators/rpm/templates/ament_cmake/template.spec.em
+++ b/bloom/generators/rpm/templates/ament_cmake/template.spec.em
@@ -4,7 +4,7 @@
 
 Name:           @(Package)
 Version:        @(Version)
-Release:        @(RPMInc)%{?dist}
+Release:        @(RPMInc)%{?dist}%{?release_suffix}
 Summary:        ROS @(Name) package
 
 License:        @(License)

--- a/bloom/generators/rpm/templates/ament_python/template.spec.em
+++ b/bloom/generators/rpm/templates/ament_python/template.spec.em
@@ -4,7 +4,7 @@
 
 Name:           @(Package)
 Version:        @(Version)
-Release:        @(RPMInc)%{?dist}
+Release:        @(RPMInc)%{?dist}%{?release_suffix}
 Summary:        ROS @(Name) package
 
 License:        @(License)

--- a/bloom/generators/rpm/templates/catkin/template.spec.em
+++ b/bloom/generators/rpm/templates/catkin/template.spec.em
@@ -4,7 +4,7 @@
 
 Name:           @(Package)
 Version:        @(Version)
-Release:        @(RPMInc)%{?dist}
+Release:        @(RPMInc)%{?dist}%{?release_suffix}
 Summary:        ROS @(Name) package
 
 License:        @(License)

--- a/bloom/generators/rpm/templates/cmake/template.spec.em
+++ b/bloom/generators/rpm/templates/cmake/template.spec.em
@@ -4,7 +4,7 @@
 
 Name:           @(Package)
 Version:        @(Version)
-Release:        @(RPMInc)%{?dist}
+Release:        @(RPMInc)%{?dist}%{?release_suffix}
 Summary:        ROS @(Name) package
 
 License:        @(License)


### PR DESCRIPTION
We can use this RPM macro to optionally append a build stamp to the release version at build time. This is necessary to achieve the same non-abi-compatible scheme as is used in the ROS debian packages.

I've been using another method to suffix the timestamps, but this way is significantly cleaner.