### PR TITLE
add debinc to allow our version to override the upstream version

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,4 +1,6 @@
 [DEFAULT]
+; release with a high debinc to avoid conflict with upstream debian of the same release version
+Debian-Version: 100
 Depends: python-yaml, python-empy, python-argparse, python-rosdep (>= 0.15.0), python-rosdistro (>= 0.8.0), python-vcstools (>= 0.1.22), python-setuptools, python-catkin-pkg (>= 0.4.3)
 Depends3: python3-yaml, python3-empy, python3-rosdep (>= 0.15.0), python3-rosdistro (>= 0.8.0), python3-vcstools (>= 0.1.22), python3-setuptools, python3-catkin-pkg (>= 0.4.3)
 Conflicts: python3-bloom


### PR DESCRIPTION
What will we need to do after merging this? Rerun our `deb` and `deb3` jobs? Or do we need a new release entirely?