### PR TITLE
Add option to disable weak RPM dependencies

### DIFF
--- a/bloom/generators/rosrpm.py
+++ b/bloom/generators/rosrpm.py
@@ -98,11 +98,9 @@ class RosRpmGenerator(RpmGenerator):
         subs['Provides'].extend(
             sanitize_package_name(rosify_package_name(g.name, self.rosdistro)) +
             '(member)' for g in package.member_of_groups)
-        if self.os_name != 'rhel' or not rpm_distro.isnumeric() or int(rpm_distro) >= 8:
-            # Weak dependencies are not supported in RHEL < 8 and will break the package.
-            subs['Supplements'].extend(
-                sanitize_package_name(rosify_package_name(g.name, self.rosdistro)) +
-                '(all)' for g in package.member_of_groups)
+        subs['Supplements'].extend(
+            sanitize_package_name(rosify_package_name(g.name, self.rosdistro)) +
+            '(all)' for g in package.member_of_groups)
 
         # ROS 2 specific bloom extensions.
         ros2_distros = [

--- a/bloom/generators/rpm/templates/ament_cmake/template.spec.em
+++ b/bloom/generators/rpm/templates/ament_cmake/template.spec.em
@@ -1,3 +1,5 @@
+%bcond_without weak_deps
+
 %global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
 %global __provides_exclude_from ^@(InstallationPrefix)/.*$
 %global __requires_exclude_from ^@(InstallationPrefix)/.*$
@@ -17,7 +19,9 @@ Source0:        %{name}-%{version}.tar.gz
 @[for p in Conflicts]Conflicts:      @p@\n@[end for]@
 @[for p in Replaces]Obsoletes:      @p@\n@[end for]@
 @[for p in Provides]Provides:       @p@\n@[end for]@
+@[if Supplements]@\n%if 0%{?with_weak_deps}
 @[for p in Supplements]Supplements:    @p@\n@[end for]@
+%endif@\n@[end if]@
 
 %description
 @(Description)

--- a/bloom/generators/rpm/templates/ament_python/template.spec.em
+++ b/bloom/generators/rpm/templates/ament_python/template.spec.em
@@ -1,3 +1,5 @@
+%bcond_without weak_deps
+
 %global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
 %global __provides_exclude_from ^@(InstallationPrefix)/.*$
 %global __requires_exclude_from ^@(InstallationPrefix)/.*$
@@ -17,7 +19,9 @@ Source0:        %{name}-%{version}.tar.gz
 @[for p in Conflicts]Conflicts:      @p@\n@[end for]@
 @[for p in Replaces]Obsoletes:      @p@\n@[end for]@
 @[for p in Provides]Provides:       @p@\n@[end for]@
+@[if Supplements]@\n%if 0%{?with_weak_deps}
 @[for p in Supplements]Supplements:    @p@\n@[end for]@
+%endif@\n@[end if]@
 
 %description
 @(Description)

--- a/bloom/generators/rpm/templates/catkin/template.spec.em
+++ b/bloom/generators/rpm/templates/catkin/template.spec.em
@@ -1,3 +1,5 @@
+%bcond_without weak_deps
+
 %global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
 %global __provides_exclude_from ^@(InstallationPrefix)/.*$
 %global __requires_exclude_from ^@(InstallationPrefix)/.*$
@@ -17,7 +19,9 @@ Source0:        %{name}-%{version}.tar.gz
 @[for p in Conflicts]Conflicts:      @p@\n@[end for]@
 @[for p in Replaces]Obsoletes:      @p@\n@[end for]@
 @[for p in Provides]Provides:       @p@\n@[end for]@
+@[if Supplements]@\n%if 0%{?with_weak_deps}
 @[for p in Supplements]Supplements:    @p@\n@[end for]@
+%endif@\n@[end if]@
 
 %description
 @(Description)

--- a/bloom/generators/rpm/templates/cmake/template.spec.em
+++ b/bloom/generators/rpm/templates/cmake/template.spec.em
@@ -1,3 +1,5 @@
+%bcond_without weak_deps
+
 %global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
 %global __provides_exclude_from ^@(InstallationPrefix)/.*$
 %global __requires_exclude_from ^@(InstallationPrefix)/.*$
@@ -17,7 +19,9 @@ Source0:        %{name}-%{version}.tar.gz
 @[for p in Conflicts]Conflicts:      @p@\n@[end for]@
 @[for p in Replaces]Obsoletes:      @p@\n@[end for]@
 @[for p in Provides]Provides:       @p@\n@[end for]@
+@[if Supplements]@\n%if 0%{?with_weak_deps}
 @[for p in Supplements]Supplements:    @p@\n@[end for]@
+%endif@\n@[end if]@
 
 %description
 @(Description)


### PR DESCRIPTION
Rather than hard-code the circumstances under which weak RPM dependencies are not supported, allow the RPM build configuration to disable them by passing `--without weak_deps` during the RPM build.