### PR TITLE
Restore return code of rosdep failure for non-interactive

### DIFF
--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -719,7 +719,7 @@ class DebianGenerator(BloomGenerator):
         while not self._check_all_keys_are_valid(peer_packages, self.rosdistro):
             error("Some of the dependencies for packages in this repository could not be resolved by rosdep.")
             if not self.interactive:
-                  sys.exit(code.GENERATOR_NO_ROSDEP_KEY_FOR_DISTRO)
+                sys.exit(code.GENERATOR_NO_ROSDEP_KEY_FOR_DISTRO)
             error("You can try to address the issues which appear above and try again if you wish.")
             try:
                 if not maybe_continue(msg="Would you like to try again?"):

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -717,8 +717,9 @@ class DebianGenerator(BloomGenerator):
         peer_packages = [p.name for p in self.packages.values()]
 
         while not self._check_all_keys_are_valid(peer_packages, self.rosdistro):
-            error("Some of the dependencies for packages in this repository could not be resolved by rosdep.",
-                  exit=not self.interactive)
+            error("Some of the dependencies for packages in this repository could not be resolved by rosdep.")
+            if not self.interactive:
+                  sys.exit(code.GENERATOR_NO_ROSDEP_KEY_FOR_DISTRO)
             error("You can try to address the issues which appear above and try again if you wish.")
             try:
                 if not maybe_continue(msg="Would you like to try again?"):

--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -584,8 +584,9 @@ class RpmGenerator(BloomGenerator):
         peer_packages = [p.name for p in self.packages.values()]
 
         while not self._check_all_keys_are_valid(peer_packages, self.rosdistro):
-            error("Some of the dependencies for packages in this repository could not be resolved by rosdep.",
-                  exit=not self.interactive)
+            error("Some of the dependencies for packages in this repository could not be resolved by rosdep.")
+            if not self.interactive:
+                  sys.exit(code.GENERATOR_NO_ROSDEP_KEY_FOR_DISTRO)
             error("You can try to address the issues which appear above and try again if you wish, "
                   "or continue without releasing into RPM-based distributions (e.g. Fedora 24).")
             try:

--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -586,7 +586,7 @@ class RpmGenerator(BloomGenerator):
         while not self._check_all_keys_are_valid(peer_packages, self.rosdistro):
             error("Some of the dependencies for packages in this repository could not be resolved by rosdep.")
             if not self.interactive:
-                  sys.exit(code.GENERATOR_NO_ROSDEP_KEY_FOR_DISTRO)
+                sys.exit(code.GENERATOR_NO_ROSDEP_KEY_FOR_DISTRO)
             error("You can try to address the issues which appear above and try again if you wish, "
                   "or continue without releasing into RPM-based distributions (e.g. Fedora 24).")
             try:


### PR DESCRIPTION
This was causing it to be impossible to release with a rpm dependency missing. 

This is fixing the return code triggered in #573 so that the higher level can catch it.

