### PR TITLE
Print devel branch for version detect

### DIFF
--- a/bloom/commands/git/release.py
+++ b/bloom/commands/git/release.py
@@ -136,7 +136,7 @@ def find_version_from_upstream(vcs_uri, vcs_type, devel_branch=None, ros_distro=
     #         return version, None
     #     warning("  Failed to find the version using raw.github.com.")
     # Try to clone the upstream repository
-    info("Checking upstream devel branch for package.xml(s)")
+    info("Checking upstream devel branch '{0}' for package.xml(s)".format(devel_branch or '<default>'))
     upstream_repo = get_upstream_repo(vcs_uri, vcs_type)
     if not upstream_repo.checkout(vcs_uri, devel_branch or ''):
         error("Failed to checkout to the upstream branch "


### PR DESCRIPTION
I had an issue this morning where I couldn't figure out why bloom was picking the previous version for re-releasing, instead of the new one. Found that for some reason the branch to pick melodic releases was still set to kinetic. One can of course go and investigate this in the release repos but in my opinion it's much quicker and cleaner if `bloom` tells us which branch it's determining the new version from.