### PR TITLE
Fix interactive prompt when running non-interactively.

### DIFF
--- a/bloom/commands/git/release.py
+++ b/bloom/commands/git/release.py
@@ -296,7 +296,7 @@ def execute_track(track, track_dict, release_inc, pretend=True, debug=False, fas
                 info('', use_prefix=False)
                 error(fmt("@|If you are @!@_@{rf}absolutely@| sure that this key is unavailable for the platform in"))
                 error(fmt("@|question, the generator can be skipped and you can proceed with the release."))
-                if maybe_continue('n', 'Skip generator action and continue with release'):
+                if interactive and maybe_continue('n', 'Skip generator action and continue with release'):
                     info("\nAction skipped, continuing with release.\n")
                     continue
 


### PR DESCRIPTION
The changes in #577 restored an interactive prompt that wasn't
functioning when #581 was being worked on. This checks for interactivity
before running the 'maybe_continue' prompt.