### PR TITLE
Update vendor typesupport dependencies for Foxy.

### DIFF
--- a/bloom/generators/rosdebian.py
+++ b/bloom/generators/rosdebian.py
@@ -110,12 +110,16 @@ class RosDebianGenerator(DebianGenerator):
                     'rmw-connext-cpp',
                     'rmw-fastrtps-cpp',
                     'rmw-implementation',
-                    'rmw-opensplice-cpp',
                     'rosidl-typesupport-connext-c',
                     'rosidl-typesupport-connext-cpp',
-                    'rosidl-typesupport-opensplice-c',
-                    'rosidl-typesupport-opensplice-cpp',
                 ]
+                # OpenSplice was dropped after Eloquent.
+                if self.rosdistro in ['bouncy', 'crystal', 'dashing', 'eloquent']:
+                    ROS2_VENDOR_TYPESUPPORT_DEPENDENCIES.extend([
+                        'rmw-opensplice-cpp',
+                        'rosidl-typesupport-opensplice-c',
+                        'rosidl-typesupport-opensplice-cpp',
+                    ])
 
                 subs['BuildDepends'] += [
                     rosify_package_name(name, self.rosdistro) for name in ROS2_VENDOR_TYPESUPPORT_DEPENDENCIES]


### PR DESCRIPTION
Since Foxy has exchanged the rmw vendor OpenSplice for CycloneDDS (which
uses the introspection typesupport) these packages are unavailable after
Foxy. They'll only be added when releasing a distribution known to
contain them. Specifically Bouncy, Crystal, Dashing, and Eloquent.

I tested this PR on Foxy with an unpushed release of rmw_dds_common and verified that the dependency on opensplice was removed. I also tested that I didn't break Dashing and Eloquent releases with an unpushed release of rcl_interfaces into Dashing which does still have the opensplice dependencies as desired.