### PR TITLE
Remove RMW implementations from vendor typesupport dependencies

### DIFF
--- a/bloom/generators/rosdebian.py
+++ b/bloom/generators/rosdebian.py
@@ -111,8 +111,12 @@ class RosDebianGenerator(DebianGenerator):
                     'rosidl-typesupport-connext-cpp',
                 ]
                 # OpenSplice was dropped after Eloquent.
+                # rmw implementations are required as dependencies up to Eloquent.
                 if self.rosdistro in ['bouncy', 'crystal', 'dashing', 'eloquent']:
                     ROS2_VENDOR_TYPESUPPORT_DEPENDENCIES.extend([
+                        'rmw-connext-cpp',
+                        'rmw-fastrtps-cpp',
+                        'rmw-implementation',
                         'rmw-opensplice-cpp',
                         'rosidl-typesupport-opensplice-c',
                         'rosidl-typesupport-opensplice-cpp',

--- a/bloom/generators/rosdebian.py
+++ b/bloom/generators/rosdebian.py
@@ -107,9 +107,6 @@ class RosDebianGenerator(DebianGenerator):
                     self.rosdistro not in ('r2b2', 'r2b3', 'ardent') and \
                     'rosidl_interface_packages' in [p.name for p in package.member_of_groups]:
                 ROS2_VENDOR_TYPESUPPORT_DEPENDENCIES = [
-                    'rmw-connext-cpp',
-                    'rmw-fastrtps-cpp',
-                    'rmw-implementation',
                     'rosidl-typesupport-connext-c',
                     'rosidl-typesupport-connext-cpp',
                 ]

--- a/bloom/generators/rosdebian.py
+++ b/bloom/generators/rosdebian.py
@@ -109,6 +109,8 @@ class RosDebianGenerator(DebianGenerator):
                 ROS2_VENDOR_TYPESUPPORT_DEPENDENCIES = [
                     'rosidl-typesupport-connext-c',
                     'rosidl-typesupport-connext-cpp',
+                    'rosidl-typesupport-fastrtps-c',
+                    'rosidl-typesupport-fastrtps-cpp',
                 ]
                 # OpenSplice was dropped after Eloquent.
                 # rmw implementations are required as dependencies up to Eloquent.

--- a/bloom/generators/rosrpm.py
+++ b/bloom/generators/rosrpm.py
@@ -120,12 +120,22 @@ class RosRpmGenerator(RpmGenerator):
                     self.rosdistro not in ('r2b2', 'r2b3', 'ardent') and \
                     'rosidl_interface_packages' in [p.name for p in package.member_of_groups]:
                 ROS2_VENDOR_TYPESUPPORT_DEPENDENCIES = [
-                    'rmw-fastrtps-cpp',
-                    'rmw-implementation',
-                    'rmw-opensplice-cpp',
-                    'rosidl-typesupport-opensplice-c',
-                    'rosidl-typesupport-opensplice-cpp',
+                    'rosidl-typesupport-connext-c',
+                    'rosidl-typesupport-connext-cpp',
+                    'rosidl-typesupport-fastrtps-c',
+                    'rosidl-typesupport-fastrtps-cpp',
                 ]
+                # OpenSplice was dropped after Eloquent.
+                # rmw implementations are required as dependencies up to Eloquent.
+                if self.rosdistro in ['bouncy', 'crystal', 'dashing', 'eloquent']:
+                    ROS2_VENDOR_TYPESUPPORT_DEPENDENCIES.extend([
+                        'rmw-connext-cpp',
+                        'rmw-fastrtps-cpp',
+                        'rmw-implementation',
+                        'rmw-opensplice-cpp',
+                        'rosidl-typesupport-opensplice-c',
+                        'rosidl-typesupport-opensplice-cpp',
+                    ])
 
                 subs['BuildDepends'] += [
                     rosify_package_name(name, self.rosdistro) for name in ROS2_VENDOR_TYPESUPPORT_DEPENDENCIES]


### PR DESCRIPTION
They are not needed from Foxy onwards. The requirement was removed in https://github.com/ros2/rosidl_typesupport/pull/62.

I'm not sure of the best way to test this change, confirming that they are indeed not actually needed. I've bloomed *rmw_dds_common* with this change, which was blocked previously because of a circular dependency with *rmw_fastrtps_cpp*: https://github.com/ros/rosdistro/pull/24704

Looking at the resultant deb, it looks like the expected typesupport libraries are installed:

```
librmw_dds_common.so
librmw_dds_common__python.so
librmw_dds_common__rosidl_generator_c.so
librmw_dds_common__rosidl_typesupport_c.so
librmw_dds_common__rosidl_typesupport_connext_c.so
librmw_dds_common__rosidl_typesupport_connext_cpp.so
librmw_dds_common__rosidl_typesupport_cpp.so
librmw_dds_common__rosidl_typesupport_introspection_c.so
librmw_dds_common__rosidl_typesupport_introspection_cpp.so
```