### PR TITLE
Drop CATKIN_BUILD_BINARY_PACKAGE from cmake RPMs

### DIFF
--- a/bloom/generators/rpm/templates/cmake/template.spec.em
+++ b/bloom/generators/rpm/templates/cmake/template.spec.em
@@ -45,7 +45,6 @@ mkdir -p obj-%{_target_platform} && cd obj-%{_target_platform}
     -DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" \
     -DCMAKE_PREFIX_PATH="@(InstallationPrefix)" \
     -DSETUPTOOLS_DEB_LAYOUT=OFF \
-    -DCATKIN_BUILD_BINARY_PACKAGE="1" \
     ..
 
 %make_build


### PR DESCRIPTION
This shouldn't make any difference to a non-catkin package, and aligns with the plain CMake debian template.