### PR TITLE
Set Python2-Depends-Name to allow releasing from Focal.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -8,4 +8,5 @@ Conflicts3: python-bloom
 Copyright-File: LICENSE.txt
 Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
 Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal jessie stretch buster
+Python2-Depends-Name: python
 X-Python3-Version: >= 3.4


### PR DESCRIPTION
Requires stdeb >= 0.9.1 and as a trade-off makes the created python 2 package uninstallable on Ubuntu Focal and later where the `python` package is called `python2` instead.