### PR TITLE
Solve shlibdeps errors in REP136 packages that use GNUInstallDirs.

### DIFF
--- a/bloom/generators/debian/templates/cmake/rules.em
+++ b/bloom/generators/debian/templates/cmake/rules.em
@@ -18,6 +18,9 @@ export PKG_CONFIG_PATH=@(InstallationPrefix)/lib/pkgconfig
 # 	https://github.com/ros-infrastructure/bloom/issues/327
 export DEB_CXXFLAGS_MAINT_APPEND=-DNDEBUG
 
+# Solve shlibdeps errors in REP136 packages that use GNUInstallDirs:
+export DEB_HOST_MULTIARCH := $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
+
 %:
 	dh $@@ -v --buildsystem=cmake
 
@@ -48,7 +51,7 @@ override_dh_shlibdeps:
 	# in the install tree and source it.  It will set things like
 	# CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
-	dh_shlibdeps -l$(CURDIR)/debian/@(Package)/@(InstallationPrefix)/lib/
+	dh_shlibdeps -l$(CURDIR)/debian/@(Package)/@(InstallationPrefix)/lib/:$(CURDIR)/debian/@(Package)/@(InstallationPrefix)/lib/${DEB_HOST_MULTIARCH}
 
 override_dh_auto_install:
 	# In case we're installing to a non-standard location, look for a setup.sh


### PR DESCRIPTION
I want to discuss whether this patch is acceptable or, on the contrary, packages are enforced in ROS *not* to use multiarchs lib prefixes. In the latter case, it would be great to have this documented somewhere, if it's not already. 
Thanks!

Pros: Any 3rd party library, well-behaved in the Debian sense of implementing multiarch prefixes, would be automatically release-able via bloom w/o changes...

Cons: none?

See: 

- https://www.ros.org/reps/rep-0136.html
- https://answers.ros.org/question/356962/should-cmake_install_libdir-be-ignored-in-rep136-packages/
- https://github.com/MRPT/mrpt/issues/1076
- Maybe related? https://answers.ros.org/question/290073/problem-building-with-non-installed-dependencies/
- Maybe related? https://www.ros.org/reps/rep-0122.html#lib 
