### PR TITLE
Add --skip-keys argument to the RPM generator

### DIFF
--- a/bloom/generators/rosrpm.py
+++ b/bloom/generators/rosrpm.py
@@ -85,7 +85,8 @@ class RosRpmGenerator(RpmGenerator):
             self.rpm_inc,
             [p.name for p in self.packages.values()],
             releaser_history=releaser_history,
-            fallback_resolver=fallback_resolver
+            fallback_resolver=fallback_resolver,
+            skip_keys=self.skip_keys
         )
         subs['Package'] = rosify_package_name(subs['Package'], self.rosdistro)
 

--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -208,9 +208,11 @@ def generate_substitutions_from_package(
     rpm_inc=0,
     peer_packages=None,
     releaser_history=None,
-    fallback_resolver=None
+    fallback_resolver=None,
+    skip_keys=None
 ):
     peer_packages = peer_packages or []
+    skip_keys = skip_keys or set()
     data = {}
     # Name, Version, Description
     data['Name'] = package.name
@@ -235,10 +237,10 @@ def generate_substitutions_from_package(
     evaluate_package_conditions(package, ros_distro)
     depends = [
         dep for dep in (package.run_depends + package.buildtool_export_depends)
-        if dep.evaluated_condition is not False]
+        if dep.evaluated_condition is not False and dep.name not in skip_keys]
     build_depends = [
         dep for dep in (package.build_depends + package.buildtool_depends + package.test_depends)
-        if dep.evaluated_condition is not False]
+        if dep.evaluated_condition is not False and dep.name not in skip_keys]
     replaces = [
         dep for dep in package.replaces
         if dep.evaluated_condition is not False]
@@ -471,12 +473,16 @@ class RpmGenerator(BloomGenerator):
             help="overrides the default installation prefix (/usr)")
         add('--os-name', default='fedora',
             help="overrides os_name, set to 'fedora' by default")
+        add('--skip-keys', nargs='+', required=False, default=[],
+            help="dependency keys which should be skipped and"
+                 " discluded from the RPM dependencies")
 
     def handle_arguments(self, args):
         self.interactive = args.interactive
         self.rpm_inc = args.rpm_inc
         self.os_name = args.os_name
         self.distros = args.distros
+        self.skip_keys = args.skip_keys or set()
         if self.distros in [None, []]:
             index = rosdistro.get_index(rosdistro.get_index_url())
             distribution_file = rosdistro.get_distribution_file(index, self.rosdistro)
@@ -548,6 +554,14 @@ class RpmGenerator(BloomGenerator):
             keys_to_resolve.extend(keys)
             for key in keys:
                 key_to_packages_which_depends_on[key].append(package.name)
+
+        for skip_key in self.skip_keys:
+            try:
+                keys_to_resolve.remove(skip_key)
+            except ValueError:
+                warning("Key '{0}' specified by --skip-keys was not found".format(skip_key))
+            else:
+                warning("Skipping dependency key '{0}' per --skip-keys".format(skip_key))
 
         os_name = self.os_name
         rosdistro = self.rosdistro
@@ -760,7 +774,8 @@ class RpmGenerator(BloomGenerator):
             self.rpm_inc,
             [p.name for p in self.packages.values()],
             releaser_history=releaser_history,
-            fallback_resolver=missing_dep_resolver
+            fallback_resolver=missing_dep_resolver,
+            skip_keys=self.skip_keys
         )
 
     def generate_rpm(self, package, rpm_distro, rpm_dir='rpm'):


### PR DESCRIPTION
There are going to be circumstances where we're going to need to skip a rosdep key in Bloom when either:
1. The dependency isn't available for the target RPM distro but isn't _strictly_ required.
2. The dependency isn't available and we can patch the package to no longer require it.
3. The "group" dependency was hard-coded and doesn't apply to the target RPM distro.

Without this option, there isn't a way to get bloom to the patching stage of generation without overriding the entire `package.xml` with an overlay or patching in the `release/foo/bar` stage, both of which would affect debian generation as well.

A prime example of this is `python3-pep8` on Eloquent, which can be patched to use `python3-pycodestyle` instead. Another is `rmw_connext_cpp`, where Connext isn't available at all in RPM form.

Requires #601