### PR TITLE
Add RHEL to the default action list

### DIFF
--- a/bloom/config.py
+++ b/bloom/config.py
@@ -204,7 +204,9 @@ DEFAULT_TEMPLATE = {
         'git-bloom-generate -y rosdebian --prefix release/:{ros_distro}'
         ' :{ros_distro} -i :{release_inc} --os-name debian --os-not-required',
         'git-bloom-generate -y rosrpm --prefix release/:{ros_distro}'
-        ' :{ros_distro} -i :{release_inc}'
+        ' :{ros_distro} -i :{release_inc} --os-name fedora',
+        'git-bloom-generate -y rosrpm --prefix release/:{ros_distro}'
+        ' :{ros_distro} -i :{release_inc} --os-name rhel',
     ]
 }
 


### PR DESCRIPTION
The default distribution for the RPM generator is Fedora. Since we're going to start generating RPMs for RHEL/CentOS, we need to update the template to perform generation for that platform specifically.