### PR TITLE
Add CMAKE_PREFIX_PATH to ament_cmake and cmake templates

### DIFF
--- a/bloom/generators/debian/templates/ament_cmake/rules.em
+++ b/bloom/generators/debian/templates/ament_cmake/rules.em
@@ -28,7 +28,8 @@ override_dh_auto_configure:
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
 	dh_auto_configure -- \
 		-DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" \
-		-DAMENT_PREFIX_PATH="@(InstallationPrefix)"
+		-DAMENT_PREFIX_PATH="@(InstallationPrefix)" \
+		-DCMAKE_PREFIX_PATH="@(InstallationPrefix)"
 
 override_dh_auto_build:
 	# In case we're installing to a non-standard location, look for a setup.sh

--- a/bloom/generators/debian/templates/cmake/rules.em
+++ b/bloom/generators/debian/templates/cmake/rules.em
@@ -26,7 +26,9 @@ override_dh_auto_configure:
 	# in the install tree and source it.  It will set things like
 	# CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
-	dh_auto_configure -- -DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)"
+	dh_auto_configure -- \
+		-DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" \
+		-DCMAKE_PREFIX_PATH="@(InstallationPrefix)"
 
 override_dh_auto_build:
 	# In case we're installing to a non-standard location, look for a setup.sh


### PR DESCRIPTION
This CMake variable is already set for the `catkin` template, but is not currently set for the `ament_cmake` and plain `cmake` templates.

The `CMAKE_INSTALL_PREFIX` variable seems to be sufficient to allow CMake to find packages which are installed under that path, however when a package is present in a system location as well as under the target installation prefix, preference is given to the system package (given that it satisfies any version requirements specified).

Setting `CMAKE_PREFIX_PATH` should give preference to the packages under that path when a package is also available as a system package and both satisfy any version requirements.

Note that the RPM templates are already using `CMAKE_PREFIX_PATH` in this way.

This is motivated by some internal discussions at Open Robotics, which were initiated after observations of this (mis)behavior in `google_benchmark_vendor` and `console_bridge_vendor` (see ros2/console_bridge_vendor#19).

I'm not anticipating any breakage caused by this change (beyond the need to resolve patching conflicts in some packages), but since it touches a significant amount of packages, I'm planning to do a minor version bump when releasing Bloom.