### PR TITLE
Use GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,10 @@
 name: bloom-ci
 
-on: [push, pull_request]
+on:
+  push:
+    branches: ['master']
+  pull_request:
+    branches: ['*']
 
 jobs:
     build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,8 +37,8 @@ jobs:
           python -m pip install nose coverage pep8
       - name: Configure rosdep
         run: |
-          sudo /usr/local/bin/rosdep init
-          /usr/local/bin/rosdep rosdep update
+          sudo `which rosdep` init
+          `which rosdep` update
       - name: Run tests
         run: |
           BLOOM_VERBOSE=1 python setup.py nosetests -s --tests test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,8 +6,8 @@ jobs:
     build:
       strategy:
         matrix:
-          os: [ubuntu-16.04, ubuntu-18.04, macos-latest]
-          python: [2.7, 3.5, 3.6, 3.7, 3.8]
+          os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, macos-latest]
+          python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
           exclude:
           - os: ubuntu-16.04
             python: 3.6
@@ -15,8 +15,18 @@ jobs:
             python: 3.7
           - os: ubuntu-16.04
             python: 3.8
+          - os: ubuntu-16.04
+            python: 3.9
           - os: ubuntu-18.04
             python: 3.5
+          - os: ubuntu-20.04
+            python: 2.7
+          - os: ubuntu-20.04
+            python: 3.5
+          - os: ubuntu-20.04
+            python: 3.6
+          - os: ubuntu-20.04
+            python: 3.7
           - os: macos-latest
             python: 3.5
           - os: macos-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,8 +37,8 @@ jobs:
           python -m pip install nose coverage pep8
       - name: Configure rosdep
         run: |
-          sudo rosdep init
-          rosdep update
+          sudo /usr/local/bin/rosdep init
+          /usr/local/bin/rosdep rosdep update
       - name: Run tests
         run: |
           BLOOM_VERBOSE=1 python setup.py nosetests -s --tests test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,44 @@
+name: bloom-ci
+
+on: [push, pull_request]
+
+jobs:
+    build:
+      strategy:
+        matrix:
+          os: [ubuntu-16.04, ubuntu-18.04, macos-latest]
+          python: [2.7, 3.5, 3.6, 3.7, 3.8]
+          exclude:
+          - os: ubuntu-16.04
+            python: 3.6
+          - os: ubuntu-16.04
+            python: 3.7
+          - os: ubuntu-16.04
+            python: 3.8
+          - os: ubuntu-18.04
+            python: 3.5
+          - os: macos-latest
+            python: 3.5
+          - os: macos-latest
+            python: 3.6
+      name: bloom tests
+      runs-on: ${{matrix.os}}
+
+      steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{matrix.python}}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{matrix.python}}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools
+          python -m pip install PyYAML argparse empy rosdep vcstools catkin-pkg python-dateutil
+          python -m pip install nose coverage pep8
+      - name: Configure rosdep
+        run: |
+          sudo rosdep init
+          rosdep update
+      - name: Run tests
+        run: |
+          BLOOM_VERBOSE=1 python setup.py nosetests -s --tests test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,7 @@ jobs:
           python -m pip install nose coverage pep8
       - name: Configure rosdep
         run: |
+          which rosdep
           sudo `which rosdep` init
           `which rosdep` update
       - name: Run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,11 @@
 language: python
 python:
-  - "2.7"
   - "3.4"  # When support for 3.4 is removed unpin the PyYAML version below.
-  - "3.6"
-  - "3.7"
-  - "3.8"
 # command to install dependencies
 install:
   - if [ $TRAVIS_PYTHON_VERSION == "3.4" ]; then pip install PyYAML==5.2; fi # Forcing PyYAML 5.2 while we retain Python 3.4 support PyYAML 5.3 and higher does not support python 3.4
-  - pip install PyYAML argparse rosdep vcstools catkin-pkg python-dateutil setuptools
+  - pip install PyYAML argparse empy rosdep vcstools catkin-pkg python-dateutil setuptools
   - pip install nose coverage pep8
-  - git clone https://github.com/dirk-thomas/empy.git /tmp/empy
-  - cd /tmp/empy
-  - python setup.py install
-  - cd -
   - sudo `which rosdep` init
   - rosdep update
 # command to run tests


### PR DESCRIPTION
Uses GitHub Actions for CI to take some of the weight off of Travis. Travis is still used for Python 3.4 support.