### PR TITLE
Add a template substitution for the ROS distro

### DIFF
--- a/bloom/generators/rosdebian.py
+++ b/bloom/generators/rosdebian.py
@@ -87,7 +87,7 @@ class RosDebianGenerator(DebianGenerator):
             releaser_history=releaser_history,
             fallback_resolver=fallback_resolver
         )
-        subs['ROSDistro'] = self.rosdistro
+        subs['Rosdistro'] = self.rosdistro
         subs['Package'] = rosify_package_name(subs['Package'], self.rosdistro)
 
         # ROS 2 specific bloom extensions.

--- a/bloom/generators/rosdebian.py
+++ b/bloom/generators/rosdebian.py
@@ -87,6 +87,7 @@ class RosDebianGenerator(DebianGenerator):
             releaser_history=releaser_history,
             fallback_resolver=fallback_resolver
         )
+        subs['ROSDistro'] = self.rosdistro
         subs['Package'] = rosify_package_name(subs['Package'], self.rosdistro)
 
         # ROS 2 specific bloom extensions.

--- a/bloom/generators/rosrpm.py
+++ b/bloom/generators/rosrpm.py
@@ -88,7 +88,7 @@ class RosRpmGenerator(RpmGenerator):
             fallback_resolver=fallback_resolver,
             skip_keys=self.skip_keys
         )
-        subs['ROSDistro'] = self.rosdistro
+        subs['Rosdistro'] = self.rosdistro
         subs['Package'] = rosify_package_name(subs['Package'], self.rosdistro)
 
         # Virtual packages

--- a/bloom/generators/rosrpm.py
+++ b/bloom/generators/rosrpm.py
@@ -88,6 +88,7 @@ class RosRpmGenerator(RpmGenerator):
             fallback_resolver=fallback_resolver,
             skip_keys=self.skip_keys
         )
+        subs['ROSDistro'] = self.rosdistro
         subs['Package'] = rosify_package_name(subs['Package'], self.rosdistro)
 
         # Virtual packages


### PR DESCRIPTION
The most common patching error I've seen in Bloom repositories manifests from carrying forward a patch from a previous track to a new one, when that patch has a hard-coded ROS distribution name in it. Unfortunately, this error often goes unnoticed when the patch modifies the weak dependencies of a package.

This substitution will allow us to roll the patches forward unmodified.