### PR TITLE
Align CMake args in RPMs with debs

### DIFF
--- a/bloom/generators/rpm/templates/ament_cmake/template.spec.em
+++ b/bloom/generators/rpm/templates/ament_cmake/template.spec.em
@@ -42,8 +42,8 @@ mkdir -p obj-%{_target_platform} && cd obj-%{_target_platform}
     -USYSCONF_INSTALL_DIR \
     -USHARE_INSTALL_PREFIX \
     -ULIB_SUFFIX \
-    -DCMAKE_INSTALL_LIBDIR="lib" \
     -DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" \
+    -DAMENT_PREFIX_PATH="@(InstallationPrefix)" \
     -DCMAKE_PREFIX_PATH="@(InstallationPrefix)" \
     -DSETUPTOOLS_DEB_LAYOUT=OFF \
     ..

--- a/bloom/generators/rpm/templates/catkin/template.spec.em
+++ b/bloom/generators/rpm/templates/catkin/template.spec.em
@@ -41,7 +41,6 @@ mkdir -p obj-%{_target_platform} && cd obj-%{_target_platform}
     -USYSCONF_INSTALL_DIR \
     -USHARE_INSTALL_PREFIX \
     -ULIB_SUFFIX \
-    -DCMAKE_INSTALL_LIBDIR="lib" \
     -DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" \
     -DCMAKE_PREFIX_PATH="@(InstallationPrefix)" \
     -DSETUPTOOLS_DEB_LAYOUT=OFF \

--- a/bloom/generators/rpm/templates/cmake/template.spec.em
+++ b/bloom/generators/rpm/templates/cmake/template.spec.em
@@ -42,7 +42,6 @@ mkdir -p obj-%{_target_platform} && cd obj-%{_target_platform}
     -USYSCONF_INSTALL_DIR \
     -USHARE_INSTALL_PREFIX \
     -ULIB_SUFFIX \
-    -DCMAKE_INSTALL_LIBDIR="lib" \
     -DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" \
     -DCMAKE_PREFIX_PATH="@(InstallationPrefix)" \
     -DSETUPTOOLS_DEB_LAYOUT=OFF \


### PR DESCRIPTION
The multiarch story has changed quite a bit since I set CMAKE_INSTALL_LIBDIR back in 2015. In particular, the ability to package plain CMake packages means that we've been forced to accept the presence of library directories other than 'lib' in ROS.

This change removes the CMAKE_INSTALL_LIBDIR override and lets GNUInstallDirs instruct some packages to use 'lib64'. A typical ROS package will still install directly to 'lib'.

One of the cases driving this removal is the vendor package pattern in ROS 2, where the CMAKE_INSTALL_LIBDIR override is not passed through from the vendor package to the external project it's wrapping, so override isn't working in all cases. Better to let the library directory differ and individually fix the packages that are misbehaving, like the one that originally motivated the change that this reverts.

Besides the removal of CMAKE_INSTALL_LIBDIR, this change also sets AMENT_PREFIX_PATH for ament_cmake packages, which is already the case in the debian generator. Besides setting SETUPTOOLS_DEB_LAYOUT, the CMake arguments between the platforms should now be much better aligned.

Reverts #372