### PR TITLE
Ignore --skip-keys arguments when inspecting actions

### DIFF
--- a/bloom/commands/git/config.py
+++ b/bloom/commands/git/config.py
@@ -34,6 +34,7 @@ from __future__ import print_function
 
 import argparse
 import copy
+import re
 import yaml
 import subprocess
 import sys
@@ -209,10 +210,14 @@ def show(args):
          default_flow_style=False))
 
 
+def drop_skip_keys(action_list):
+    return [re.sub(' --skip-keys.*?(?= -|$)', '', a) for a in action_list]
+
+
 def update_track(track_dict):
     for key, value in DEFAULT_TEMPLATE.items():
         if key in ['actions']:
-            if track_dict[key] != DEFAULT_TEMPLATE[key]:
+            if drop_skip_keys(track_dict[key]) != DEFAULT_TEMPLATE[key]:
                 warning("Your track's '{0}' configuration is not the same as the default."
                         .format(key))
                 default = 'n'


### PR DESCRIPTION
The prompt to update a package's action list is useful for encouraging maintainers to take on new generators, but it seems that some maintainers are accepting an update to the default action list without trying to figure out why the list differs to begin with.

The --skip-keys argument was added to the RPM generator to work around some non-critical missing dependencies in various packages, but the argument keeps getting removed. This change doesn't prevent the argument from being removed when a legitimate difference is detected, but it does prevent the prompt from being raised when the action list differs only by --skip-keys arguments.

Follow-up to #602