### PR TITLE
make generator_cmd in bloom-generate required

### DIFF
--- a/bloom/commands/generate.py
+++ b/bloom/commands/generate.py
@@ -61,6 +61,7 @@ def create_subparsers(parser, generator_cmds):
     subparser = parser.add_subparsers(
         title='generate commands',
         metavar=metavar,
+        required=True,
         description='Call `bloom-generate {0} -h` for help on a each generate command.'.format(metavar),
         dest='generator_cmd'
     )


### PR DESCRIPTION
This handles when `bloom-generate` gets called without argument and
aborts processing.
This fixes #580.