### PR TITLE
Enable output from CTest failures in RPMs

### DIFF
--- a/bloom/generators/rpm/templates/ament_cmake/template.spec.em
+++ b/bloom/generators/rpm/templates/ament_cmake/template.spec.em
@@ -67,7 +67,7 @@ if [ -n "$TEST_TARGET" ]; then
 # CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi
 CTEST_OUTPUT_ON_FAILURE=1 \
-  %make_build -C obj-%{_target_platform} $TEST_TARGET || echo "RPM TESTS FAILED"
+    %make_build -C obj-%{_target_platform} $TEST_TARGET || echo "RPM TESTS FAILED"
 else echo "RPM TESTS SKIPPED"; fi
 %endif
 

--- a/bloom/generators/rpm/templates/ament_cmake/template.spec.em
+++ b/bloom/generators/rpm/templates/ament_cmake/template.spec.em
@@ -66,7 +66,8 @@ if [ -n "$TEST_TARGET" ]; then
 # in the install tree and source it.  It will set things like
 # CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi
-%make_build -C obj-%{_target_platform} $TEST_TARGET || echo "RPM TESTS FAILED"
+CTEST_OUTPUT_ON_FAILURE=1 \
+  %make_build -C obj-%{_target_platform} $TEST_TARGET || echo "RPM TESTS FAILED"
 else echo "RPM TESTS SKIPPED"; fi
 %endif
 

--- a/bloom/generators/rpm/templates/cmake/template.spec.em
+++ b/bloom/generators/rpm/templates/cmake/template.spec.em
@@ -65,7 +65,8 @@ if [ -n "$TEST_TARGET" ]; then
 # in the install tree and source it.  It will set things like
 # CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi
-%make_build -C obj-%{_target_platform} $TEST_TARGET || echo "RPM TESTS FAILED"
+CTEST_OUTPUT_ON_FAILURE=1 \
+    %make_build -C obj-%{_target_platform} $TEST_TARGET || echo "RPM TESTS FAILED"
 else echo "RPM TESTS SKIPPED"; fi
 %endif
 


### PR DESCRIPTION
The `CTEST_OUTPUT_ON_FAILURE` environment variable can be used to get more information on test failures. Since it is an environment variable, it is unlikely to affect non-CTest tests that can be run when `make test` is invoked.