### PR TITLE
Rewire the typesupport dependencies for post-Foxy.

### DIFF
--- a/bloom/generators/rosdebian.py
+++ b/bloom/generators/rosdebian.py
@@ -108,14 +108,20 @@ class RosDebianGenerator(DebianGenerator):
                     self.rosdistro not in ('r2b2', 'r2b3', 'ardent') and \
                     'rosidl_interface_packages' in [p.name for p in package.member_of_groups]:
                 ROS2_VENDOR_TYPESUPPORT_DEPENDENCIES = [
-                    'rosidl-typesupport-connext-c',
-                    'rosidl-typesupport-connext-cpp',
                     'rosidl-typesupport-fastrtps-c',
                     'rosidl-typesupport-fastrtps-cpp',
                 ]
+
+                # Connext was changed to a new rmw that doesn't require typesupport after Foxy
+                if self.rosdistro in ('bouncy', 'crystal', 'dashing', 'eloquent', 'foxy'):
+                    ROS2_VENDOR_TYPESUPPORT_DEPENDENCIES.extend([
+                        'rosidl-typesupport-connext-c',
+                        'rosidl-typesupport-connext-cpp',
+                    ])
+
                 # OpenSplice was dropped after Eloquent.
                 # rmw implementations are required as dependencies up to Eloquent.
-                if self.rosdistro in ['bouncy', 'crystal', 'dashing', 'eloquent']:
+                if self.rosdistro in ('bouncy', 'crystal', 'dashing', 'eloquent'):
                     ROS2_VENDOR_TYPESUPPORT_DEPENDENCIES.extend([
                         'rmw-connext-cpp',
                         'rmw-fastrtps-cpp',


### PR DESCRIPTION
Up to foxy, the connext RMW required typesupport packages.
Starting in Galactic, the new connext RMW no longer requires
those packages.  Revamp the logic here so that we only add
those connext typesupports for distros before Galactic.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

@nuclearsandwich @cottsay This is part of https://github.com/rticommunity/rmw_connextdds/issues/9 .  I'm not quite sure how to test it, so any hints there are welcome.  Also, once we merge this we'll really need a new bloom release so that we can re-release all of the interface packages into Rolling/Galactic to remove this dependency.