### PR TITLE
Specify patch level for RPMs

### DIFF
--- a/bloom/generators/rpm/templates/ament_cmake/template.spec.em
+++ b/bloom/generators/rpm/templates/ament_cmake/template.spec.em
@@ -28,7 +28,7 @@ Source0:        %{name}-%{version}.tar.gz
 @(Description)
 
 %prep
-%autosetup
+%autosetup -p1
 
 %build
 # In case we're installing to a non-standard location, look for a setup.sh

--- a/bloom/generators/rpm/templates/ament_python/template.spec.em
+++ b/bloom/generators/rpm/templates/ament_python/template.spec.em
@@ -28,7 +28,7 @@ Source0:        %{name}-%{version}.tar.gz
 @(Description)
 
 %prep
-%autosetup
+%autosetup -p1
 
 %build
 # In case we're installing to a non-standard location, look for a setup.sh

--- a/bloom/generators/rpm/templates/catkin/template.spec.em
+++ b/bloom/generators/rpm/templates/catkin/template.spec.em
@@ -27,7 +27,7 @@ Source0:        %{name}-%{version}.tar.gz
 @(Description)
 
 %prep
-%autosetup
+%autosetup -p1
 
 %build
 # In case we're installing to a non-standard location, look for a setup.sh

--- a/bloom/generators/rpm/templates/cmake/template.spec.em
+++ b/bloom/generators/rpm/templates/cmake/template.spec.em
@@ -28,7 +28,7 @@ Source0:        %{name}-%{version}.tar.gz
 @(Description)
 
 %prep
-%autosetup
+%autosetup -p1
 
 %build
 # In case we're installing to a non-standard location, look for a setup.sh


### PR DESCRIPTION
It's far more common to use patch level 1 in RPMs, mainly because that's the default patch level that the unified diffs produced by git use.

Merging this would mean one fewer change to make when debugging RPM issues locally using 'rpmbuild'.

I know that template changes can sometimes result in patching failures - making changes like this that reduce development friction while relatively few ROS 2 packages have been generated by the community is worth 1 or 2 merge conflicts.