### PR TITLE
Use basic authentication with new personal access tokens.

### DIFF
--- a/bloom/github.py
+++ b/bloom/github.py
@@ -80,7 +80,10 @@ def auth_header_from_basic_auth(user, password):
 
 
 def auth_header_from_oauth_token(token):
-    return "token " + token
+    auth_str = '{0}:{1}'.format('nuclearsandwich', token)
+    if sys.version_info >= (3, 0):
+        auth_str = auth_str.encode()
+    return "Basic {0}".format(base64.b64encode(auth_str))
 
 
 def get_bloom_headers(auth=None):

--- a/bloom/github.py
+++ b/bloom/github.py
@@ -79,11 +79,17 @@ def auth_header_from_basic_auth(user, password):
     return "Basic {0}".format(base64.b64encode(auth_str))
 
 
+def auth_header_from_token(username, token):
+    # Handle new GitHub personal access tokens
+    # which are used with basic authentication.
+    if token.startswith('ghp_'):
+        return auth_header_from_basic_auth(username, token)
+    else:
+        return auth_header_from_oauth_token(token)
+
+
 def auth_header_from_oauth_token(token):
-    auth_str = '{0}:{1}'.format('nuclearsandwich', token)
-    if sys.version_info >= (3, 0):
-        auth_str = auth_str.encode()
-    return "Basic {0}".format(base64.b64encode(auth_str))
+    return "token " + token
 
 
 def get_bloom_headers(auth=None):
@@ -302,7 +308,7 @@ def get_github_interface(quiet=False):
             token = config.get('oauth_token', None)
             username = config.get('github_user', None)
             if token and username:
-                return Github(username, auth=auth_header_from_oauth_token(token), token=token)
+                return Github(username, auth=auth_header_from_token(username, token), token=token)
     if not os.path.isdir(os.path.dirname(oauth_config_path)):
         os.makedirs(os.path.dirname(oauth_config_path))
     if quiet:


### PR DESCRIPTION
New personal access tokens on GitHub are not created as oauth tokens and
are not usable with token authentication. Instead they're used as the
password for basic authentication.

More info on these new tokens is in [this GitHub blog post](https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/).

This is a minimal change to ensure that bloom can continue to work with
these new tokens.