### PR TITLE
Prepare 0.10.4 release.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+0.10.4 (2021-04-07 10:00:00 -0700)
+----------------------------------
+- Use basic authentication with the new personal access tokens. `#627 <https://github.com/ros-infrastructure/bloom/issues/627>`_
+- Add a fast check for the likely fork name. `#629 <https://github.com/ros-infrastructure/bloom/issues/629>`_
+- Specify patch level in RPM templates. `#626 <https://github.com/ros-infrastructure/bloom/issues/626>`_
+- Collect manually created token rather than attempting to create one. `#628 <https://github.com/ros-infrastructure/bloom/issues/628>`_
+
 0.10.3 (2021-03-25 11:08:00 -0700)
 ----------------------------------
 - Rewire the typesupport dependencies for post-Foxy. `#625 <https://github.com/ros-infrastructure/bloom/issues/625>`_

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if sys.version_info[0] == 2 and sys.version_info[1] <= 6:
 
 setup(
     name='bloom',
-    version='0.10.3',
+    version='0.10.4',
     packages=find_packages(exclude=['test', 'test.*']),
     package_data={
         'bloom.generators.debian': [


### PR DESCRIPTION
- Use basic authentication with the new personal access tokens. #627
- Add a fast check for the likely fork name. #629
- Specify patch level in RPM templates. #626
- Collect manually created token rather than attempting to create one. #628

If approved this PR should be fast-forwarded rather than squashed.