### PR TITLE
Fix token authentication error.

### DIFF
--- a/bloom/github.py
+++ b/bloom/github.py
@@ -76,7 +76,10 @@ def auth_header_from_basic_auth(user, password):
     auth_str = '{0}:{1}'.format(user, password)
     if sys.version_info >= (3, 0):
         auth_str = auth_str.encode()
-    return "Basic {0}".format(base64.b64encode(auth_str))
+    b64_encoded = base64.b64encode(auth_str)
+    if sys.version_info >= (3, 0):
+        b64_encoded = b64_encoded.decode()
+    return "Basic {0}".format(b64_encoded)
 
 
 def auth_header_from_token(username, token):


### PR DESCRIPTION
The new personal access tokens from GitHub for which support was first
added in bloom in #627 use basic authentication like a username and
password rather than the OAuth token authentication used by OAuth tokens
and previous iterations of the personal access token. When adding
support for this it seems like I missed a trick and as a result the
authentication header was being sent as
`Basic b'base64encodeduserandtoken'` rather than
`Basic base64encodeduserandtoken`.

I have to do an experimental bisect to determine why this issue is only
showing up now. Perhaps it's been an issue since the jump to python3 but
since basic authentication was only ever used as a springboard for token
auth it was overlooked when reported.

I am pretty sure that this will address #632 as well as tokens being immediately rejected when entered via the prompt added in #628.

Closes #632 