### PR TITLE
Fall back to 3-way merge when applying patches

### DIFF
--- a/bloom/commands/git/patch/import_cmd.py
+++ b/bloom/commands/git/patch/import_cmd.py
@@ -90,7 +90,7 @@ def import_patches(directory=None):
         # Now checkout back to the original branch and import them
         checkout(current_branch, directory=directory)
         try:
-            cmd = 'git am {0}*.patch'.format(tmp_dir + os.sep)
+            cmd = 'git am --3way {0}*.patch'.format(tmp_dir + os.sep)
             execute_command(cmd, cwd=directory)
         except subprocess.CalledProcessError as e:
             warning("Failed to apply one or more patches for the "


### PR DESCRIPTION
It seems that git's 3-way merge is a bit more forgiving than the default 'clean application' approach. Specifying this option will attempt a 3-way merge to apply the patch only after a patch doesn't apply cleanly.

This seems to have eliminated some manual patch application on at least a couple of repositories during the galactic branching process.