### PR TITLE
Shallow clone rosdistro for creating PRs

### DIFF
--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -764,7 +764,7 @@ Increasing version of package(s) in repository `{repository}` to `{version}`:
                     warning("Skipping the pull request...")
                     return
                 _my_run('git checkout -b {new_branch}'.format(**locals()))
-                _my_run("git pull {rosdistro_url} {base_info[branch]}".format(**locals()),
+                _my_run("git pull {rosdistro_url} {base_info[branch]} --depth=1".format(**locals()),
                         "Pulling latest rosdistro branch")
                 rosdistro_index_commit = get_rosdistro_index_commit()
                 if rosdistro_index_commit is not None:


### PR DESCRIPTION
The history in rosdistro is _really_ long, and it can take quite a while to pull it when creating PRs. Since we're just going to make a single commit on top, there's really no reason to pull the full history.

This makes creating the PR faster - even on fast internet connections.