### PR TITLE
Bump debhelper compat to 11

### DIFF
--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -424,8 +424,7 @@ def generate_substitutions_from_package(
         if not maybe_continue('n', 'Continue anyways'):
             sys.exit("User quit.")
     data['changelogs'] = changelogs
-    # Use debhelper version 7 for oneric, otherwise 9
-    data['debhelper_version'] = 7 if os_version in ['oneiric'] else 9
+    data['debhelper_version'] = 11
     # Summarize dependencies
     summarize_dependency_mapping(data, depends, build_depends, resolved_deps)
     # Copyright


### PR DESCRIPTION
All supported Ubuntu distros have at least 11:

https://packages.ubuntu.com/search?suite=all&searchon=names&keywords=debhelper