### PR TITLE
Begin RPM build directories with '.'

### DIFF
--- a/bloom/generators/rpm/templates/ament_cmake/template.spec.em
+++ b/bloom/generators/rpm/templates/ament_cmake/template.spec.em
@@ -35,7 +35,7 @@ Source0:        %{name}-%{version}.tar.gz
 # in the install tree and source it.  It will set things like
 # CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi
-mkdir -p obj-%{_target_platform} && cd obj-%{_target_platform}
+mkdir -p .obj-%{_target_platform} && cd .obj-%{_target_platform}
 %cmake3 \
     -UINCLUDE_INSTALL_DIR \
     -ULIB_INSTALL_DIR \
@@ -55,19 +55,19 @@ mkdir -p obj-%{_target_platform} && cd obj-%{_target_platform}
 # in the install tree and source it.  It will set things like
 # CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi
-%make_install -C obj-%{_target_platform}
+%make_install -C .obj-%{_target_platform}
 
 %if 0%{?with_tests}
 %check
 # Look for a Makefile target with a name indicating that it runs tests
-TEST_TARGET=$(%__make -qp -C obj-%{_target_platform} | sed "s/^\(test\|check\):.*/\\1/;t f;d;:f;q0")
+TEST_TARGET=$(%__make -qp -C .obj-%{_target_platform} | sed "s/^\(test\|check\):.*/\\1/;t f;d;:f;q0")
 if [ -n "$TEST_TARGET" ]; then
 # In case we're installing to a non-standard location, look for a setup.sh
 # in the install tree and source it.  It will set things like
 # CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi
 CTEST_OUTPUT_ON_FAILURE=1 \
-    %make_build -C obj-%{_target_platform} $TEST_TARGET || echo "RPM TESTS FAILED"
+    %make_build -C .obj-%{_target_platform} $TEST_TARGET || echo "RPM TESTS FAILED"
 else echo "RPM TESTS SKIPPED"; fi
 %endif
 

--- a/bloom/generators/rpm/templates/catkin/template.spec.em
+++ b/bloom/generators/rpm/templates/catkin/template.spec.em
@@ -34,7 +34,7 @@ Source0:        %{name}-%{version}.tar.gz
 # in the install tree that was dropped by catkin, and source it.  It will
 # set things like CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi
-mkdir -p obj-%{_target_platform} && cd obj-%{_target_platform}
+mkdir -p .obj-%{_target_platform} && cd .obj-%{_target_platform}
 %cmake3 \
     -UINCLUDE_INSTALL_DIR \
     -ULIB_INSTALL_DIR \
@@ -54,7 +54,7 @@ mkdir -p obj-%{_target_platform} && cd obj-%{_target_platform}
 # in the install tree that was dropped by catkin, and source it.  It will
 # set things like CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi
-%make_install -C obj-%{_target_platform}
+%make_install -C .obj-%{_target_platform}
 
 %files
 @(InstallationPrefix)

--- a/bloom/generators/rpm/templates/cmake/template.spec.em
+++ b/bloom/generators/rpm/templates/cmake/template.spec.em
@@ -35,7 +35,7 @@ Source0:        %{name}-%{version}.tar.gz
 # in the install tree and source it.  It will set things like
 # CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi
-mkdir -p obj-%{_target_platform} && cd obj-%{_target_platform}
+mkdir -p .obj-%{_target_platform} && cd .obj-%{_target_platform}
 %cmake3 \
     -UINCLUDE_INSTALL_DIR \
     -ULIB_INSTALL_DIR \
@@ -54,19 +54,19 @@ mkdir -p obj-%{_target_platform} && cd obj-%{_target_platform}
 # in the install tree and source it.  It will set things like
 # CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi
-%make_install -C obj-%{_target_platform}
+%make_install -C .obj-%{_target_platform}
 
 %if 0%{?with_tests}
 %check
 # Look for a Makefile target with a name indicating that it runs tests
-TEST_TARGET=$(%__make -qp -C obj-%{_target_platform} | sed "s/^\(test\|check\):.*/\\1/;t f;d;:f;q0")
+TEST_TARGET=$(%__make -qp -C .obj-%{_target_platform} | sed "s/^\(test\|check\):.*/\\1/;t f;d;:f;q0")
 if [ -n "$TEST_TARGET" ]; then
 # In case we're installing to a non-standard location, look for a setup.sh
 # in the install tree and source it.  It will set things like
 # CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi
 CTEST_OUTPUT_ON_FAILURE=1 \
-    %make_build -C obj-%{_target_platform} $TEST_TARGET || echo "RPM TESTS FAILED"
+    %make_build -C .obj-%{_target_platform} $TEST_TARGET || echo "RPM TESTS FAILED"
 else echo "RPM TESTS SKIPPED"; fi
 %endif
 


### PR DESCRIPTION
The standard practice for CMake build directories in RPM packages is to create a unique subdirectory within the source tree. This clashes with many of the linters in ROS and ROS 2, which recursively process the package from the root of the package directory, leading to numerous linter failure messages during the RPM test phase.

It appears that the majority of these linters will ignore a 'hidden' directory which begins with a '.', so naming our build directory as such may help prevent the linters from crawling where we don't want them to.