### PR TITLE
Conditionally exclude test dependencies

### DIFF
--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -318,7 +318,10 @@ def generate_substitutions_from_package(
         dep for dep in (package.run_depends + package.buildtool_export_depends)
         if dep.evaluated_condition is not False]
     build_depends = [
-        dep for dep in (package.build_depends + package.buildtool_depends + package.test_depends)
+        dep for dep in (package.build_depends + package.buildtool_depends)
+        if dep.evaluated_condition is not False]
+    test_depends = [
+        dep for dep in (package.test_depends)
         if dep.evaluated_condition is not False]
     replaces = [
         dep for dep in package.replaces
@@ -336,7 +339,8 @@ def generate_substitutions_from_package(
         set(format_depends(depends, resolved_deps))
     )
     data['BuildDepends'] = sorted(
-        set(format_depends(build_depends, resolved_deps))
+        set(format_depends(build_depends, resolved_deps)) |
+        set(p + ' <!nocheck>' for p in format_depends(test_depends, resolved_deps))
     )
     data['Replaces'] = sorted(
         set(format_depends(replaces, resolved_deps))

--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -239,7 +239,10 @@ def generate_substitutions_from_package(
         dep for dep in (package.run_depends + package.buildtool_export_depends)
         if dep.evaluated_condition is not False and dep.name not in skip_keys]
     build_depends = [
-        dep for dep in (package.build_depends + package.buildtool_depends + package.test_depends)
+        dep for dep in (package.build_depends + package.buildtool_depends)
+        if dep.evaluated_condition is not False and dep.name not in skip_keys]
+    test_depends = [
+        dep for dep in (package.test_depends)
         if dep.evaluated_condition is not False and dep.name not in skip_keys]
     replaces = [
         dep for dep in package.replaces
@@ -258,6 +261,9 @@ def generate_substitutions_from_package(
     )
     data['BuildDepends'] = sorted(
         set(format_depends(build_depends, resolved_deps))
+    )
+    data['TestDepends'] = sorted(
+        set(format_depends(test_depends, resolved_deps)).difference(data['BuildDepends'])
     )
     data['Replaces'] = sorted(
         set(format_depends(replaces, resolved_deps))

--- a/bloom/generators/rpm/templates/ament_cmake/template.spec.em
+++ b/bloom/generators/rpm/templates/ament_cmake/template.spec.em
@@ -23,6 +23,9 @@ Source0:        %{name}-%{version}.tar.gz
 @[if Supplements]@\n%if 0%{?with_weak_deps}
 @[for p in Supplements]Supplements:    @p@\n@[end for]@
 %endif@\n@[end if]@
+@[if TestDepends]@\n%if 0%{?with_tests}
+@[for p in TestDepends]BuildRequires:  @p@\n@[end for]@
+%endif@\n@[end if]@
 
 %description
 @(Description)
@@ -46,6 +49,9 @@ mkdir -p obj-%{_target_platform} && cd obj-%{_target_platform}
     -DAMENT_PREFIX_PATH="@(InstallationPrefix)" \
     -DCMAKE_PREFIX_PATH="@(InstallationPrefix)" \
     -DSETUPTOOLS_DEB_LAYOUT=OFF \
+%if !0%{?with_tests}
+    -DBUILD_TESTING=OFF \
+%endif
     ..
 
 %make_build

--- a/bloom/generators/rpm/templates/ament_python/template.spec.em
+++ b/bloom/generators/rpm/templates/ament_python/template.spec.em
@@ -23,6 +23,9 @@ Source0:        %{name}-%{version}.tar.gz
 @[if Supplements]@\n%if 0%{?with_weak_deps}
 @[for p in Supplements]Supplements:    @p@\n@[end for]@
 %endif@\n@[end if]@
+@[if TestDepends]@\n%if 0%{?with_tests}
+@[for p in TestDepends]BuildRequires:  @p@\n@[end for]@
+%endif@\n@[end if]@
 
 %description
 @(Description)

--- a/bloom/generators/rpm/templates/catkin/template.spec.em
+++ b/bloom/generators/rpm/templates/catkin/template.spec.em
@@ -1,3 +1,4 @@
+%bcond_without tests
 %bcond_without weak_deps
 
 %global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
@@ -22,6 +23,9 @@ Source0:        %{name}-%{version}.tar.gz
 @[if Supplements]@\n%if 0%{?with_weak_deps}
 @[for p in Supplements]Supplements:    @p@\n@[end for]@
 %endif@\n@[end if]@
+@[if TestDepends]@\n%if 0%{?with_tests}
+@[for p in TestDepends]BuildRequires:  @p@\n@[end for]@
+%endif@\n@[end if]@
 
 %description
 @(Description)
@@ -45,6 +49,10 @@ mkdir -p obj-%{_target_platform} && cd obj-%{_target_platform}
     -DCMAKE_PREFIX_PATH="@(InstallationPrefix)" \
     -DSETUPTOOLS_DEB_LAYOUT=OFF \
     -DCATKIN_BUILD_BINARY_PACKAGE="1" \
+%if !0%{?with_tests}
+    -DBUILD_TESTING=OFF \
+    -DCATKIN_ENABLE_TESTING=OFF \
+%endif
     ..
 
 %make_build

--- a/bloom/generators/rpm/templates/cmake/template.spec.em
+++ b/bloom/generators/rpm/templates/cmake/template.spec.em
@@ -23,6 +23,9 @@ Source0:        %{name}-%{version}.tar.gz
 @[if Supplements]@\n%if 0%{?with_weak_deps}
 @[for p in Supplements]Supplements:    @p@\n@[end for]@
 %endif@\n@[end if]@
+@[if TestDepends]@\n%if 0%{?with_tests}
+@[for p in TestDepends]BuildRequires:  @p@\n@[end for]@
+%endif@\n@[end if]@
 
 %description
 @(Description)
@@ -45,6 +48,9 @@ mkdir -p obj-%{_target_platform} && cd obj-%{_target_platform}
     -DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" \
     -DCMAKE_PREFIX_PATH="@(InstallationPrefix)" \
     -DSETUPTOOLS_DEB_LAYOUT=OFF \
+%if !0%{?with_tests}
+    -DBUILD_TESTING=OFF \
+%endif
     ..
 
 %make_build


### PR DESCRIPTION
In the debian generator, we can decorate the BuildDepends to omit them if the `nocheck` flag is set.

For RPMs, there isn't a standard mechanism for skipping tests but we actually created a build flag for skipping tests, so the only work here was to wire that custom flag into the dependency enumeration.

I still need to do some testing on the debian side. In particular, I'm not sure if `nocheck` automatically sets `ENABLE_TESTING=OFF` in the cmake builds. Either way, I think we'll need to update it to set `CATKIN_ENABLE_TESTING` appropriately in the catkin template.