### PR TITLE
Include more license information in RPM spec files

### DIFF
--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -222,6 +222,7 @@ def generate_substitutions_from_package(
     if not package.licenses or not package.licenses[0]:
         error("No license set for package '{0}', aborting.".format(package.name), exit=True)
     data['License'] = ' and '.join(package.licenses)
+    data['LicenseFiles'] = sorted(set(l.file for l in package.licenses if l.file))
     # Websites
     websites = [str(url) for url in package.urls if url.type == 'website']
     data['Homepage'] = websites[0] if websites else ''

--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -221,7 +221,7 @@ def generate_substitutions_from_package(
     # License
     if not package.licenses or not package.licenses[0]:
         error("No license set for package '{0}', aborting.".format(package.name), exit=True)
-    data['License'] = package.licenses[0]
+    data['License'] = ' and '.join(package.licenses)
     # Websites
     websites = [str(url) for url in package.urls if url.type == 'website']
     data['Homepage'] = websites[0] if websites else ''

--- a/bloom/generators/rpm/templates/ament_cmake/template.spec.em
+++ b/bloom/generators/rpm/templates/ament_cmake/template.spec.em
@@ -72,6 +72,7 @@ else echo "RPM TESTS SKIPPED"; fi
 %endif
 
 %files
+@[for lf in LicenseFiles]%license @lf@\n@[end for]@
 @(InstallationPrefix)
 
 %changelog@

--- a/bloom/generators/rpm/templates/ament_python/template.spec.em
+++ b/bloom/generators/rpm/templates/ament_python/template.spec.em
@@ -58,6 +58,7 @@ else echo "RPM TESTS SKIPPED"; fi
 %endif
 
 %files
+@[for lf in LicenseFiles]%license @lf@\n@[end for]@
 @(InstallationPrefix)
 
 %changelog@

--- a/bloom/generators/rpm/templates/catkin/template.spec.em
+++ b/bloom/generators/rpm/templates/catkin/template.spec.em
@@ -57,6 +57,7 @@ if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.
 %make_install -C obj-%{_target_platform}
 
 %files
+@[for lf in LicenseFiles]%license @lf@\n@[end for]@
 @(InstallationPrefix)
 
 %changelog@

--- a/bloom/generators/rpm/templates/cmake/template.spec.em
+++ b/bloom/generators/rpm/templates/cmake/template.spec.em
@@ -71,6 +71,7 @@ else echo "RPM TESTS SKIPPED"; fi
 %endif
 
 %files
+@[for lf in LicenseFiles]%license @lf@\n@[end for]@
 @(InstallationPrefix)
 
 %changelog@


### PR DESCRIPTION
Following the Fedora guidelines, multiple licenses can be expressed in the `License` field: https://fedoraproject.org/wiki/Packaging:LicensingGuidelines?rd=Packaging/LicensingGuidelines#Multiple_Licensing_Scenarios

We can also include the actual license text files if they are listed in the package manifest - a feature introduced in the manifest specifications v3.

Note that this will cause a new build failure if the file referenced by the manifest is not present.