### PR TITLE
Machine-readable debian/copyright file

### DIFF
--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -468,7 +468,7 @@ def generate_substitutions_from_package(
             license_text = open(license_file, 'r').read().rstrip()
             licenses.append((str(l), format_multiline(license_text)))
         else:
-            licenses.append((str(l), ''))
+            licenses.append((str(l), 'See repository for full license text'))
     data['Licenses'] = licenses
 
     def convertToUnicode(obj):

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -333,6 +333,9 @@ def generate_substitutions_from_package(
     repositories = [str(url) for url in package.urls if url.type == 'repository']
     repository = repositories[0] if repositories else ''
     data['Source'] = repository
+    bugtrackers = [str(url) for url in package.urls if url.type == 'bugtracker']
+    bugtracker = bugtrackers[0] if bugtrackers else ''
+    data['BugTracker'] = bugtracker
     # Debian Increment Number
     data['DebianInc'] = '' if native else '-{0}'.format(deb_inc)
     # Debian Package Format

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -241,6 +241,32 @@ def format_description(value):
     return u"{0}.\n {1}".format(parts[0], parts[1].strip())
 
 
+def format_multiline(value):
+    """
+    Format multi-line text to appear in a Debian control file (or similar file)
+    as a 'multiline' field type.
+
+    https://www.debian.org/doc/debian-policy/ch-controlfields#syntax-of-control-files
+    """
+    # Insert a leading '.' if the first line is blank
+    if value.startswith('\n'):
+        value = '.' + value
+
+    # Insert a trailing '.' if the last line is blank
+    if value.endswith('\n'):
+        value = value + '.'
+
+    # Add a '.' to intermediate blank lines
+    value = value.replace('\n\n', '\n.\n')
+    # Once more, to handle consecutive blank lines
+    value = value.replace('\n\n', '\n.\n')
+
+    # Indent each additional line by a single space
+    value = value.replace('\n', '\n ')
+
+    return value
+
+
 def get_changelogs(package, releaser_history=None):
     if releaser_history is None:
         warning("No historical releaser history, using current maintainer name "
@@ -440,7 +466,7 @@ def generate_substitutions_from_package(
                 error("License file '{}' is not found.".
                       format(license_file), exit=True)
             license_text = open(license_file, 'r').read().rstrip()
-            licenses.append((str(l), license_text))
+            licenses.append((str(l), format_multiline(license_text)))
         else:
             licenses.append((str(l), ''))
     data['Licenses'] = licenses

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -304,6 +304,9 @@ def generate_substitutions_from_package(
     if homepage == '':
         warning("No homepage set, defaulting to ''")
     data['Homepage'] = homepage
+    repositories = [str(url) for url in package.urls if url.type == 'repository']
+    repository = repositories[0] if repositories else ''
+    data['Source'] = repository
     # Debian Increment Number
     data['DebianInc'] = '' if native else '-{0}'.format(deb_inc)
     # Debian Package Format
@@ -430,18 +433,17 @@ def generate_substitutions_from_package(
     summarize_dependency_mapping(data, depends, build_depends, resolved_deps)
     # Copyright
     licenses = []
-    separator = '\n' + '=' * 80 + '\n\n'
     for l in package.licenses:
         if hasattr(l, 'file') and l.file is not None:
             license_file = os.path.join(os.path.dirname(package.filename), l.file)
             if not os.path.exists(license_file):
                 error("License file '{}' is not found.".
                       format(license_file), exit=True)
-            license_text = open(license_file, 'r').read()
-            if not license_text.endswith('\n'):
-                license_text += '\n'
-            licenses.append(license_text)
-    data['Copyright'] = separator.join(licenses)
+            license_text = open(license_file, 'r').read().rstrip()
+            licenses.append((str(l), license_text))
+        else:
+            licenses.append((str(l), ''))
+    data['Licenses'] = licenses
 
     def convertToUnicode(obj):
         if sys.version_info.major == 2:

--- a/bloom/generators/debian/templates/ament_cmake/copyright.em
+++ b/bloom/generators/debian/templates/ament_cmake/copyright.em
@@ -1,1 +1,11 @@
-@(Copyright)
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: @(Name)
+Upstream-Contact: @(Maintainers.replace(', ', '\n '))
+@[if Source and Source != '']Source: @(Source)@\n@[end if]@
+@[for License, Text in Licenses]@
+
+Files: *
+Copyright: See package copyright in source code for details
+License: @(License)
+@[if Text and Text != '']@(Text.replace('\n\n', '\n.\n').replace('\n\n', '\n.\n').replace('\n', '\n '))@\n@[end if]@
+@[end for]@

--- a/bloom/generators/debian/templates/ament_cmake/copyright.em
+++ b/bloom/generators/debian/templates/ament_cmake/copyright.em
@@ -1,11 +1,11 @@
-Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Format: Bloom subset of https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: @(Name)
 Upstream-Contact: @(Maintainers.replace(', ', '\n '))
 @[if Source and Source != '']Source: @(Source)@\n@[end if]@
 @[for License, Text in Licenses]@
 
-Files: *
+Files: package.xml
 Copyright: See package copyright in source code for details
 License: @(License)
-@[if Text and Text != ''] @(Text)@\n@[end if]@
+ @(Text)
 @[end for]@

--- a/bloom/generators/debian/templates/ament_cmake/copyright.em
+++ b/bloom/generators/debian/templates/ament_cmake/copyright.em
@@ -1,7 +1,7 @@
 Format: Bloom subset of https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: @(Name)
-@[if BugTracker and BugTracker != '']Upstream-Contact: @(BugTracker)@\n@[end if]@
-@[if Source and Source != '']Source: @(Source)@\n@[end if]@
+@[if BugTracker]Upstream-Contact: @(BugTracker)@\n@[end if]@
+@[if Source]Source: @(Source)@\n@[end if]@
 @[for License, Text in Licenses]@
 
 Files: See file headers in repository for details

--- a/bloom/generators/debian/templates/ament_cmake/copyright.em
+++ b/bloom/generators/debian/templates/ament_cmake/copyright.em
@@ -7,5 +7,5 @@ Upstream-Contact: @(Maintainers.replace(', ', '\n '))
 Files: *
 Copyright: See package copyright in source code for details
 License: @(License)
-@[if Text and Text != '']@(Text.replace('\n\n', '\n.\n').replace('\n\n', '\n.\n').replace('\n', '\n '))@\n@[end if]@
+@[if Text and Text != ''] @(Text)@\n@[end if]@
 @[end for]@

--- a/bloom/generators/debian/templates/ament_cmake/copyright.em
+++ b/bloom/generators/debian/templates/ament_cmake/copyright.em
@@ -1,10 +1,10 @@
 Format: Bloom subset of https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: @(Name)
-Upstream-Contact: @(Maintainers.replace(', ', '\n '))
+@[if BugTracker and BugTracker != '']Upstream-Contact: @(BugTracker)@\n@[end if]@
 @[if Source and Source != '']Source: @(Source)@\n@[end if]@
 @[for License, Text in Licenses]@
 
-Files: package.xml
+Files: See file headers in repository for details
 Copyright: See package copyright in source code for details
 License: @(License)
  @(Text)

--- a/bloom/generators/debian/templates/ament_python/copyright.em
+++ b/bloom/generators/debian/templates/ament_python/copyright.em
@@ -1,1 +1,11 @@
-@(Copyright)
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: @(Name)
+Upstream-Contact: @(Maintainers.replace(', ', '\n '))
+@[if Source and Source != '']Source: @(Source)@\n@[end if]@
+@[for License, Text in Licenses]@
+
+Files: *
+Copyright: See package copyright in source code for details
+License: @(License)
+@[if Text and Text != '']@(Text.replace('\n\n', '\n.\n').replace('\n\n', '\n.\n').replace('\n', '\n '))@\n@[end if]@
+@[end for]@

--- a/bloom/generators/debian/templates/ament_python/copyright.em
+++ b/bloom/generators/debian/templates/ament_python/copyright.em
@@ -1,11 +1,11 @@
-Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Format: Bloom subset of https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: @(Name)
 Upstream-Contact: @(Maintainers.replace(', ', '\n '))
 @[if Source and Source != '']Source: @(Source)@\n@[end if]@
 @[for License, Text in Licenses]@
 
-Files: *
+Files: package.xml
 Copyright: See package copyright in source code for details
 License: @(License)
-@[if Text and Text != ''] @(Text)@\n@[end if]@
+ @(Text)
 @[end for]@

--- a/bloom/generators/debian/templates/ament_python/copyright.em
+++ b/bloom/generators/debian/templates/ament_python/copyright.em
@@ -1,7 +1,7 @@
 Format: Bloom subset of https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: @(Name)
-@[if BugTracker and BugTracker != '']Upstream-Contact: @(BugTracker)@\n@[end if]@
-@[if Source and Source != '']Source: @(Source)@\n@[end if]@
+@[if BugTracker]Upstream-Contact: @(BugTracker)@\n@[end if]@
+@[if Source]Source: @(Source)@\n@[end if]@
 @[for License, Text in Licenses]@
 
 Files: See file headers in repository for details

--- a/bloom/generators/debian/templates/ament_python/copyright.em
+++ b/bloom/generators/debian/templates/ament_python/copyright.em
@@ -7,5 +7,5 @@ Upstream-Contact: @(Maintainers.replace(', ', '\n '))
 Files: *
 Copyright: See package copyright in source code for details
 License: @(License)
-@[if Text and Text != '']@(Text.replace('\n\n', '\n.\n').replace('\n\n', '\n.\n').replace('\n', '\n '))@\n@[end if]@
+@[if Text and Text != ''] @(Text)@\n@[end if]@
 @[end for]@

--- a/bloom/generators/debian/templates/ament_python/copyright.em
+++ b/bloom/generators/debian/templates/ament_python/copyright.em
@@ -1,10 +1,10 @@
 Format: Bloom subset of https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: @(Name)
-Upstream-Contact: @(Maintainers.replace(', ', '\n '))
+@[if BugTracker and BugTracker != '']Upstream-Contact: @(BugTracker)@\n@[end if]@
 @[if Source and Source != '']Source: @(Source)@\n@[end if]@
 @[for License, Text in Licenses]@
 
-Files: package.xml
+Files: See file headers in repository for details
 Copyright: See package copyright in source code for details
 License: @(License)
  @(Text)

--- a/bloom/generators/debian/templates/catkin/copyright.em
+++ b/bloom/generators/debian/templates/catkin/copyright.em
@@ -1,1 +1,11 @@
-@(Copyright)
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: @(Name)
+Upstream-Contact: @(Maintainers.replace(', ', '\n '))
+@[if Source and Source != '']Source: @(Source)@\n@[end if]@
+@[for License, Text in Licenses]@
+
+Files: *
+Copyright: See package copyright in source code for details
+License: @(License)
+@[if Text and Text != '']@(Text.replace('\n\n', '\n.\n').replace('\n\n', '\n.\n').replace('\n', '\n '))@\n@[end if]@
+@[end for]@

--- a/bloom/generators/debian/templates/catkin/copyright.em
+++ b/bloom/generators/debian/templates/catkin/copyright.em
@@ -1,11 +1,11 @@
-Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Format: Bloom subset of https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: @(Name)
 Upstream-Contact: @(Maintainers.replace(', ', '\n '))
 @[if Source and Source != '']Source: @(Source)@\n@[end if]@
 @[for License, Text in Licenses]@
 
-Files: *
+Files: package.xml
 Copyright: See package copyright in source code for details
 License: @(License)
-@[if Text and Text != ''] @(Text)@\n@[end if]@
+ @(Text)
 @[end for]@

--- a/bloom/generators/debian/templates/catkin/copyright.em
+++ b/bloom/generators/debian/templates/catkin/copyright.em
@@ -1,7 +1,7 @@
 Format: Bloom subset of https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: @(Name)
-@[if BugTracker and BugTracker != '']Upstream-Contact: @(BugTracker)@\n@[end if]@
-@[if Source and Source != '']Source: @(Source)@\n@[end if]@
+@[if BugTracker]Upstream-Contact: @(BugTracker)@\n@[end if]@
+@[if Source]Source: @(Source)@\n@[end if]@
 @[for License, Text in Licenses]@
 
 Files: See file headers in repository for details

--- a/bloom/generators/debian/templates/catkin/copyright.em
+++ b/bloom/generators/debian/templates/catkin/copyright.em
@@ -7,5 +7,5 @@ Upstream-Contact: @(Maintainers.replace(', ', '\n '))
 Files: *
 Copyright: See package copyright in source code for details
 License: @(License)
-@[if Text and Text != '']@(Text.replace('\n\n', '\n.\n').replace('\n\n', '\n.\n').replace('\n', '\n '))@\n@[end if]@
+@[if Text and Text != ''] @(Text)@\n@[end if]@
 @[end for]@

--- a/bloom/generators/debian/templates/catkin/copyright.em
+++ b/bloom/generators/debian/templates/catkin/copyright.em
@@ -1,10 +1,10 @@
 Format: Bloom subset of https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: @(Name)
-Upstream-Contact: @(Maintainers.replace(', ', '\n '))
+@[if BugTracker and BugTracker != '']Upstream-Contact: @(BugTracker)@\n@[end if]@
 @[if Source and Source != '']Source: @(Source)@\n@[end if]@
 @[for License, Text in Licenses]@
 
-Files: package.xml
+Files: See file headers in repository for details
 Copyright: See package copyright in source code for details
 License: @(License)
  @(Text)

--- a/bloom/generators/debian/templates/cmake/copyright.em
+++ b/bloom/generators/debian/templates/cmake/copyright.em
@@ -1,1 +1,11 @@
-@(Copyright)
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: @(Name)
+Upstream-Contact: @(Maintainers.replace(', ', '\n '))
+@[if Source and Source != '']Source: @(Source)@\n@[end if]@
+@[for License, Text in Licenses]@
+
+Files: *
+Copyright: See package copyright in source code for details
+License: @(License)
+@[if Text and Text != '']@(Text.replace('\n\n', '\n.\n').replace('\n\n', '\n.\n').replace('\n', '\n '))@\n@[end if]@
+@[end for]@

--- a/bloom/generators/debian/templates/cmake/copyright.em
+++ b/bloom/generators/debian/templates/cmake/copyright.em
@@ -1,11 +1,11 @@
-Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Format: Bloom subset of https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: @(Name)
 Upstream-Contact: @(Maintainers.replace(', ', '\n '))
 @[if Source and Source != '']Source: @(Source)@\n@[end if]@
 @[for License, Text in Licenses]@
 
-Files: *
+Files: package.xml
 Copyright: See package copyright in source code for details
 License: @(License)
-@[if Text and Text != ''] @(Text)@\n@[end if]@
+ @(Text)
 @[end for]@

--- a/bloom/generators/debian/templates/cmake/copyright.em
+++ b/bloom/generators/debian/templates/cmake/copyright.em
@@ -1,7 +1,7 @@
 Format: Bloom subset of https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: @(Name)
-@[if BugTracker and BugTracker != '']Upstream-Contact: @(BugTracker)@\n@[end if]@
-@[if Source and Source != '']Source: @(Source)@\n@[end if]@
+@[if BugTracker]Upstream-Contact: @(BugTracker)@\n@[end if]@
+@[if Source]Source: @(Source)@\n@[end if]@
 @[for License, Text in Licenses]@
 
 Files: See file headers in repository for details

--- a/bloom/generators/debian/templates/cmake/copyright.em
+++ b/bloom/generators/debian/templates/cmake/copyright.em
@@ -7,5 +7,5 @@ Upstream-Contact: @(Maintainers.replace(', ', '\n '))
 Files: *
 Copyright: See package copyright in source code for details
 License: @(License)
-@[if Text and Text != '']@(Text.replace('\n\n', '\n.\n').replace('\n\n', '\n.\n').replace('\n', '\n '))@\n@[end if]@
+@[if Text and Text != ''] @(Text)@\n@[end if]@
 @[end for]@

--- a/bloom/generators/debian/templates/cmake/copyright.em
+++ b/bloom/generators/debian/templates/cmake/copyright.em
@@ -1,10 +1,10 @@
 Format: Bloom subset of https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: @(Name)
-Upstream-Contact: @(Maintainers.replace(', ', '\n '))
+@[if BugTracker and BugTracker != '']Upstream-Contact: @(BugTracker)@\n@[end if]@
 @[if Source and Source != '']Source: @(Source)@\n@[end if]@
 @[for License, Text in Licenses]@
 
-Files: package.xml
+Files: See file headers in repository for details
 Copyright: See package copyright in source code for details
 License: @(License)
  @(Text)

--- a/test/system_tests/test_catkin_release.py
+++ b/test/system_tests/test_catkin_release.py
@@ -378,14 +378,9 @@ def test_multi_package_repository(directory=None):
                     format_version = int(re.search('format="(\d+)"',
                                                    package_xml).group(1))
                 # Is there a copyright file for this pkg?
-                if format_version <= 2:
-                    assert not os.path.exists(
-                        os.path.join('debian', 'copyright')), \
-                        "debian/copyright should not be generated"
-                else:
-                    with open('debian/copyright', 'r') as f:
-                        assert pkg + ' license' in f.read(), \
-                            "debian/copyright does not include right license text"
+                with open('debian/copyright', 'r') as f:
+                    assert (format_version <= 2) ^ (pkg + ' license' in f.read()), \
+                        "debian/copyright does not include right license text"
 
 @in_temporary_directory
 def test_upstream_tag_special_tag(directory=None):


### PR DESCRIPTION
This should be a reasonable starting place for supporting machine-readable debian/copyright files in the debian generator. Manifests which utilize the 'file' attribute in their 'licence' elements should end up with their LICENSE text in the debian/copyright file as before, but now the file will be formatted according to [Debian Policy 4.6.0.1](https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/).

Fixes #645 