### PR TITLE
Drop support for EOL Ubuntu distros

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     build:
       strategy:
         matrix:
-          os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, macos-latest]
+          os: [ubuntu-18.04, ubuntu-20.04, macos-latest]
           python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
           exclude:
           - os: ubuntu-16.04

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -6,7 +6,7 @@ Depends3: python3-yaml, python3-empy, python3-rosdep (>= 0.15.0), python3-rosdis
 Conflicts: python3-bloom
 Conflicts3: python-bloom
 Copyright-File: LICENSE.txt
-Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
-Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal jessie stretch buster
+Suite: bionic jessie stretch buster
+Suite3: bionic focal jessie stretch buster
 Python2-Depends-Name: python
 X-Python3-Version: >= 3.4


### PR DESCRIPTION
https://wiki.ubuntu.com/Releases#List_of_releases

- Xenial:  Apr 2021
- Yakkety: Jul 2017
- Zesty:   Jan 2019
- Artful:  Jul 2018
- Cosmic:  Oct 2018
- Disco:   Apr 2019
- Eoan:    Oct 2019

Should we consider dropping Jessie as well? https://www.debian.org/releases/