### PR TITLE
Un-normalize catkin_pkg dependency name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import find_packages, setup
 
 install_requires = [
-    'catkin-pkg >= 0.4.3',
+    'catkin_pkg >= 0.4.3',
     'setuptools',
     'empy',
     'python-dateutil',


### PR DESCRIPTION
It seems that this dependency actually uses an underscore in the package name, but it typically "just works" because pip normalizes it.

https://github.com/ros-infrastructure/catkin_pkg/blob/52f0a367733e4e161622d4f205ce95ed8ec8c164/setup.py#L19

Motivation for this change is that colcon doesn't currently support the "loose" name comparison that pip employs.