### PR TITLE
fix: global argument handling with non-existent args

### DIFF
--- a/bloom/commands/generate.py
+++ b/bloom/commands/generate.py
@@ -84,4 +84,4 @@ def main(sysargs=None):
     args = parser.parse_args(sysargs)
     handle_global_arguments(args)
 
-    sys.exit(args.func(args) or 0)
+    sys.exit(args.func(args) if 'func' in args else 0)

--- a/bloom/util.py
+++ b/bloom/util.py
@@ -305,12 +305,13 @@ def get_git_clone_state_quiet():
 
 def handle_global_arguments(args):
     global _pdb, _quiet
-    enable_debug(args.debug or 'DEBUG' in os.environ)
-    _pdb = args.pdb
-    _quiet = args.quiet
-    if args.no_color:
+    enable_debug(args.debug if 'debug' in args else None or 'DEBUG' in os.environ)
+    _pdb = args.pdb if 'pdb' in args else None
+    _quiet = args.quiet if 'quiet' in args else None
+    no_color = args.no_color if 'no_color' in args else None
+    if no_color:
         disable_ANSI_colors()
-    disable_git_clone(args.unsafe or 'BLOOM_UNSAFE' in os.environ)
+    disable_git_clone(args.unsafe if 'unsafe' in args else None or 'BLOOM_UNSAFE' in os.environ)
     quiet_git_clone_warning('BLOOM_UNSAFE_QUIET' in os.environ)
 
 


### PR DESCRIPTION
When running bloom on ubuntu jammy (python 3.10) I was getting these errors:

```
↳ bloom-generate 
/home/russ/.local/lib/python3.10/site-packages/pkg_resources/__init__.py:122: PkgResourcesDeprecationWarning:  is an invalid version and will not be supported in a future release
  warnings.warn(
/home/russ/.local/lib/python3.10/site-packages/pkg_resources/__init__.py:122: PkgResourcesDeprecationWarning:  is an invalid version and will not be supported in a future release
  warnings.warn(
Traceback (most recent call last):
  File "/usr/bin/bloom-generate", line 33, in <module>
    sys.exit(load_entry_point('bloom==0.10.7', 'console_scripts', 'bloom-generate')())
  File "/usr/lib/python3/dist-packages/bloom/commands/generate.py", line 85, in main
    handle_global_arguments(args)
  File "/usr/lib/python3/dist-packages/bloom/util.py", line 308, in handle_global_arguments
    enable_debug(args.debug or 'DEBUG' in os.environ)
AttributeError: 'Namespace' object has no attribute 'debug'
```