### PR TITLE
Exit early on patch failure if bloom is being run non-interactively.

### DIFF
--- a/bloom/commands/git/patch/import_cmd.py
+++ b/bloom/commands/git/patch/import_cmd.py
@@ -93,6 +93,10 @@ def import_patches(directory=None):
             cmd = 'git am --3way {0}*.patch'.format(tmp_dir + os.sep)
             execute_command(cmd, cwd=directory)
         except subprocess.CalledProcessError as e:
+            if "BLOOM_NON_INTERACTIVE" in os.environ:
+                error("Failed to apply one or more patches for the "
+                        "'{0}' branch.".format(str(e)))
+                sys.exit("'git-bloom-patch import' aborted.")
             warning("Failed to apply one or more patches for the "
                     "'{0}' branch.".format(str(e)))
             info('', use_prefix=False)

--- a/bloom/commands/git/patch/import_cmd.py
+++ b/bloom/commands/git/patch/import_cmd.py
@@ -95,7 +95,7 @@ def import_patches(directory=None):
         except subprocess.CalledProcessError as e:
             if "BLOOM_NON_INTERACTIVE" in os.environ:
                 error("Failed to apply one or more patches for the "
-                        "'{0}' branch.".format(str(e)))
+                      "'{0}' branch.".format(str(e)))
                 sys.exit("'git-bloom-patch import' aborted.")
             warning("Failed to apply one or more patches for the "
                     "'{0}' branch.".format(str(e)))

--- a/bloom/commands/git/patch/import_cmd.py
+++ b/bloom/commands/git/patch/import_cmd.py
@@ -93,7 +93,8 @@ def import_patches(directory=None):
             cmd = 'git am --3way {0}*.patch'.format(tmp_dir + os.sep)
             execute_command(cmd, cwd=directory)
         except subprocess.CalledProcessError as e:
-            if "BLOOM_NON_INTERACTIVE" in os.environ:
+            # Only try interactive resolution if stdin is a terminal.
+            if not sys.stdin.isatty():
                 error("Failed to apply one or more patches for the "
                       "'{0}' branch.".format(str(e)))
                 sys.exit("'git-bloom-patch import' aborted.")

--- a/bloom/commands/git/release.py
+++ b/bloom/commands/git/release.py
@@ -259,6 +259,9 @@ def execute_track(track, track_dict, release_inc, pretend=True, debug=False, fas
     else:
         archive_file = '{name}.tar.gz'.format(**settings)
     settings['archive_path'] = os.path.join(archive_dir_path, archive_file)
+    actions_env = os.environ.copy()
+    if not interactive:
+        actions_env['BLOOM_NON_INTERACTIVE'] = '1'
     # execute actions
     info("", use_prefix=False)
     info("Executing release track '{0}'".format(track))
@@ -283,7 +286,7 @@ def execute_track(track, track_dict, release_inc, pretend=True, debug=False, fas
         templated_action = templated_action.split()
         templated_action[0] = find_full_path(templated_action[0])
         p = subprocess.Popen(templated_action, stdout=stdout, stderr=stderr,
-                             shell=False, env=os.environ.copy())
+                             shell=False, env=actions_env)
         out, err = p.communicate()
         if bloom.util._quiet:
             info(out, use_prefix=False)

--- a/bloom/commands/git/release.py
+++ b/bloom/commands/git/release.py
@@ -259,9 +259,6 @@ def execute_track(track, track_dict, release_inc, pretend=True, debug=False, fas
     else:
         archive_file = '{name}.tar.gz'.format(**settings)
     settings['archive_path'] = os.path.join(archive_dir_path, archive_file)
-    actions_env = os.environ.copy()
-    if not interactive:
-        actions_env['BLOOM_NON_INTERACTIVE'] = '1'
     # execute actions
     info("", use_prefix=False)
     info("Executing release track '{0}'".format(track))
@@ -286,7 +283,7 @@ def execute_track(track, track_dict, release_inc, pretend=True, debug=False, fas
         templated_action = templated_action.split()
         templated_action[0] = find_full_path(templated_action[0])
         p = subprocess.Popen(templated_action, stdout=stdout, stderr=stderr,
-                             shell=False, env=actions_env)
+                             shell=False, env=os.environ.copy())
         out, err = p.communicate()
         if bloom.util._quiet:
             info(out, use_prefix=False)


### PR DESCRIPTION
If git-bloom-release is run non-interactively then that should be
propagated to the actions command so that actions are not blocked on
interactivity.

This patch uses an environment variable to send that message since the action commands do not have a --non-interactive flag and their command-line arguments are all defined statically in the tracks file so using the environment makes more sense than further munging those tracks unless we consider adding a {non-interactive} template to the tracks string, which would require updating all outstanding tracks files, also not my favorite idea.

I haven't audited the code for additional interactive points inside tracks files and I'm not yet sure if I mean to or if I plan to play "whack-a-mole" with them as I find them naturally over time.