### PR TITLE
Update release suites for bloom.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -6,7 +6,7 @@ Depends3: python3-yaml, python3-empy, python3-rosdep (>= 0.15.0), python3-rosdis
 Conflicts: python3-bloom
 Conflicts3: python-bloom
 Copyright-File: LICENSE.txt
-Suite: bionic jessie stretch buster
-Suite3: bionic focal jessie stretch buster
+Suite: bionic buster
+Suite3: bionic focal jammy buster bullseye
 Python2-Depends-Name: python
 X-Python3-Version: >= 3.4


### PR DESCRIPTION
Drop Debian Jessie and Stretch from all releases.
Add Ubuntu Jammy and Debian Bullseye to python3 releases.