### PR TITLE
Update package apt install

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,7 +32,7 @@ How do I install bloom?
 
 On Ubuntu the recommended method is to use apt::
 
-    $ sudo apt-get install python-bloom
+    $ sudo apt-get install python3-bloom
 
 On other systems you can install bloom via pypi::
 


### PR DESCRIPTION
Both the recommended ROS1 version (Noetic) and recommended ROS2 version (Galactic) target Ubuntu Focal (20.04). On 20.04, the correct apt-install is actually `python3-bloom`: the current documentation specifies `python-bloom`, which is unavailable and fails. This merge updates the installation instruction to reflect this change.