### PR TITLE
Use inspect.getfullargspec where available

### DIFF
--- a/test/utils/common.py
+++ b/test/utils/common.py
@@ -142,7 +142,10 @@ def in_temporary_directory(f):
     @functools.wraps(f)
     def decorated(*args, **kwds):
         with temporary_directory() as directory:
-            from inspect import getargspec
+            try:
+                from inspect import getfullargspec as getargspec
+            except ImportError:
+                from inspect import getargspec
             # If it takes directory of kwargs and kwds does already have
             # directory, inject it
             if 'directory' not in kwds and 'directory' in getargspec(f)[0]:


### PR DESCRIPTION
The `inspect.getargspec` function has been deprecated since Python 3.0, where `inspect.getfullargspec` was introduced to replace it. We still need to support getargspec for Python 2.

This change is needed to support Python 3.11, where `inspect.getargspec` [has been removed](https://docs.python.org/3.11/whatsnew/3.11.html#removed).