### PR TITLE
ensure subparser is required

### DIFF
--- a/bloom/commands/generate.py
+++ b/bloom/commands/generate.py
@@ -58,15 +58,16 @@ def load_generator_description(generator_name):
 
 def create_subparsers(parser, generator_cmds):
     metavar = '[' + ' | '.join(generator_cmds) + ']'
-    subparser = parser.add_subparsers(
+    subparsers = parser.add_subparsers(
         title='generate commands',
         metavar=metavar,
         description='Call `bloom-generate {0} -h` for help on a each generate command.'.format(metavar),
-        dest='generator_cmd'
+        dest='generator_cmd',
+        required=True
     )
     for generator_cmd in generator_cmds:
         desc = load_generator_description(generator_cmd)
-        cmd_parser = subparser.add_parser(desc['title'], description=desc['description'])
+        cmd_parser = subparsers.add_parser(desc['title'], description=desc['description'])
         cmd_parser = desc['prepare_arguments'](cmd_parser)
         cmd_parser.set_defaults(func=desc['main'])
         add_global_arguments(cmd_parser)


### PR DESCRIPTION
When ``bloom-generate`` is called without arguments, this now shows:

```sh
usage: bloom-generate [-h] [debian | rosdebian | rosrpm | rpm] ...
bloom-generate: error: the following arguments are required: [debian | rosdebian | rosrpm | rpm]
```

Rather than continuing without an argument and causing an unrelated error:

```sh
/home/russ/.local/lib/python3.10/site-packages/pkg_resources/__init__.py:122: PkgResourcesDeprecationWarning:  is an invalid version and will not be supported in a future release
  warnings.warn(
/home/russ/.local/lib/python3.10/site-packages/pkg_resources/__init__.py:122: PkgResourcesDeprecationWarning:  is an invalid version and will not be supported in a future release
  warnings.warn(
Traceback (most recent call last):
  File "/usr/bin/bloom-generate", line 33, in <module>
    sys.exit(load_entry_point('bloom==0.10.7', 'console_scripts', 'bloom-generate')())
  File "/usr/lib/python3/dist-packages/bloom/commands/generate.py", line 85, in main
    handle_global_arguments(args)
  File "/usr/lib/python3/dist-packages/bloom/util.py", line 308, in handle_global_arguments
    enable_debug(args.debug or 'DEBUG' in os.environ)
AttributeError: 'Namespace' object has no attribute 'debug'
```

This fixes the issue #665 is trying to solve.