### PR TITLE
Dry-run with set-upstream origin master, in case remote repo isn't initialized yet

### DIFF
--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -927,7 +927,7 @@ def _perform_release(
         info(fmt("@{bf}@!==> @|@!") + str(cmd))
         subprocess.check_call(cmd, shell=True)
         # Dry run will authenticate, but not push
-        cmd = 'git push --set-upstream origin {0} --dry-run'.format(BLOOM_CONFIG_BRANCH)
+        cmd = 'git push origin {0} --dry-run'.format(BLOOM_CONFIG_BRANCH)
         info(fmt("@{bf}@!==> @|@!") + str(cmd))
         subprocess.check_call(cmd, shell=True)
     except subprocess.CalledProcessError:

--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -926,7 +926,7 @@ def _perform_release(
         info(fmt("@{bf}@!==> @|@!") + str(cmd))
         subprocess.check_call(cmd, shell=True)
         # Dry run will authenticate, but not push
-        cmd = 'git push --dry-run'
+        cmd = 'git push --set-upstream origin master --dry-run'
         info(fmt("@{bf}@!==> @|@!") + str(cmd))
         subprocess.check_call(cmd, shell=True)
     except subprocess.CalledProcessError:

--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -927,7 +927,7 @@ def _perform_release(
         info(fmt("@{bf}@!==> @|@!") + str(cmd))
         subprocess.check_call(cmd, shell=True)
         # Dry run will authenticate, but not push
-        cmd = f'git push --set-upstream origin {BLOOM_CONFIG_BRANCH} --dry-run'
+        cmd = 'git push --set-upstream origin {0} --dry-run'.format(BLOOM_CONFIG_BRANCH)
         info(fmt("@{bf}@!==> @|@!") + str(cmd))
         subprocess.check_call(cmd, shell=True)
     except subprocess.CalledProcessError:

--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -62,6 +62,7 @@ except ImportError:
 
 import bloom
 
+from bloom.config import BLOOM_CONFIG_BRANCH
 from bloom.config import get_tracks_dict_raw
 from bloom.config import upconvert_bloom_to_config_branch
 from bloom.config import write_tracks_dict_raw
@@ -926,7 +927,7 @@ def _perform_release(
         info(fmt("@{bf}@!==> @|@!") + str(cmd))
         subprocess.check_call(cmd, shell=True)
         # Dry run will authenticate, but not push
-        cmd = 'git push --set-upstream origin master --dry-run'
+        cmd = f'git push --set-upstream origin {BLOOM_CONFIG_BRANCH} --dry-run'
         info(fmt("@{bf}@!==> @|@!") + str(cmd))
         subprocess.check_call(cmd, shell=True)
     except subprocess.CalledProcessError:

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -9,4 +9,5 @@ Copyright-File: LICENSE.txt
 Suite: bionic buster
 Suite3: bionic focal jammy buster bullseye
 Python2-Depends-Name: python
+Dh-python3-params: --no-guessing-deps
 X-Python3-Version: >= 3.4


### PR DESCRIPTION
Currently, a maintainer must initialize a release repository before running bloom (such as by adding a README.md). If a release repository is uninitialized, bloom will complain such as:

```sh

==> git push --dry-run
fatal: The current branch master has no upstream branch.
To push the current branch and set the remote as upstream, use

    git push --set-upstream origin master

Cannot push to remote release repository.
```

The change in this PR makes bloom work with uninitialized remote repositories. (Hence alleviating the need to manually initialize)

Apart from this ``git push --dry-run`` command that was failing, bloom seems to be able to work with an uninitialized remote repository completely fine.

Resolves: ros2-gbp/ros2-gbp-github-org#47

Signed-off-by: Kenji Brameld <kenjibrameld@gmail.com>