### PR TITLE
Add Defaults for src/doc information

### DIFF
--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -391,7 +391,7 @@ def generate_ros_distro_diff(track, repository, distro, override_release_reposit
         defaults = defaults or {}
         while True:
             info("VCS Type must be one of git, svn, hg, or bzr.")
-            default = defaults.get('type', None)
+            default = defaults.get('type', track_dict.get('vcs_type'))
             insert = '' if default is None else ' [{0}]'.format(default)
             vcs_type = safe_input('VCS type{0}: '.format(insert))
             if not vcs_type:
@@ -403,7 +403,7 @@ def generate_ros_distro_diff(track, repository, distro, override_release_reposit
                 return {}
         data['type'] = vcs_type
         while True:
-            default = defaults.get('url', None)
+            default = defaults.get('url', track_dict.get('vcs_uri'))
             insert = '' if default is None else ' [{0}]'.format(default)
             url = safe_input('VCS url{0}: '.format(insert))
             if not url:
@@ -419,7 +419,7 @@ def generate_ros_distro_diff(track, repository, distro, override_release_reposit
         data['url'] = url
         while True:
             info("VCS version must be a branch, tag, or commit, e.g. master or 0.1.0")
-            default = defaults.get('version', None)
+            default = defaults.get('version', track_dict.get('devel_branch'))
             insert = '' if default is None else ' [{0}]'.format(default)
             version = safe_input('VCS version{0}: '.format(insert))
             if not version:


### PR DESCRIPTION
If you are adding a new repository to rosdistro, it will prompt you to add Documentation and Source information, but it will not use any of the information previously used to fill in the defaults. This PR uses the `track_dict` object to populate the defaults for the fields. 

So instead of 

```
Would you like to add documentation information for this repository? [Y/n]? 
==> Looking for a doc entry for this repository in a different distribution...
No existing doc entries found for use as defaults.
Please enter your repository information for the doc generation job.
This information should point to the repository from which documentation should be generated.
VCS Type must be one of git, svn, hg, or bzr.
VCS type: git
VCS url: https://github.com/MetroRobots/ros_system_fingerprint.git
VCS version must be a branch, tag, or commit, e.g. master or 0.1.0
VCS version: ros2

```
(where I manually typed `git/https://github.com/MetroRobots/ros_system_fingerprint.git/ros2`)


we get

```
Would you like to add documentation information for this repository? [Y/n]? 
==> Looking for a doc entry for this repository in a different distribution...
No existing doc entries found for use as defaults.
Please enter your repository information for the doc generation job.
This information should point to the repository from which documentation should be generated.
VCS Type must be one of git, svn, hg, or bzr.
VCS type [git]: 
VCS url [https://github.com/MetroRobots/ros_system_fingerprint.git]: 
VCS version must be a branch, tag, or commit, e.g. master or 0.1.0
VCS version [ros2]:
```

(where `git/https://github.com/MetroRobots/ros_system_fingerprint.git/ros2` were autopopulated as the defaults and I just had to hit enter three times)
