### PR TITLE
Set CMAKE_INSTALL_LIBDIR=lib in debian/control for ROS1 packages

### DIFF
--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -83,6 +83,8 @@ from bloom.commands.git.patch.common import set_patch_config
 
 from bloom.packages import get_package_data
 
+from bloom.rosdistro_api import get_distribution_type
+
 from bloom.util import code
 from bloom.util import to_unicode
 from bloom.util import execute_command
@@ -344,6 +346,9 @@ def generate_substitutions_from_package(
     data['Package'] = sanitize_package_name(package.name)
     # Installation prefix
     data['InstallationPrefix'] = installation_prefix
+    # ROS version
+    ros_distro_type = get_distribution_type(ros_distro)
+    data['RosVersion'] = int(ros_distro_type[3:])
     # Resolve dependencies
     evaluate_package_conditions(package, ros_distro)
     depends = [

--- a/bloom/generators/debian/templates/catkin/rules.em
+++ b/bloom/generators/debian/templates/catkin/rules.em
@@ -30,9 +30,12 @@ override_dh_auto_configure:
 	# In case we're installing to a non-standard location, look for a setup.sh
 	# in the install tree that was dropped by catkin, and source it.  It will
 	# set things like CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
+        # Note that CMAKE_INSTALL_LIBDIR is set to lib/<multiarch> by default, but
+        # only affects packages that use GNUInstallDirs.
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
 	dh_auto_configure -- \
 		-DCATKIN_BUILD_BINARY_PACKAGE="1" \
+		-DCMAKE_INSTALL_LIBDIR="lib" \
 		-DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" \
 		-DCMAKE_PREFIX_PATH="@(InstallationPrefix)" \
 		$(BUILD_TESTING_ARG)

--- a/bloom/generators/debian/templates/cmake/rules.em
+++ b/bloom/generators/debian/templates/cmake/rules.em
@@ -32,10 +32,12 @@ DEB_HOST_GNU_TYPE ?= $(shell dpkg-architecture -qDEB_HOST_GNU_TYPE)
 override_dh_auto_configure:
 	# In case we're installing to a non-standard location, look for a setup.sh
 	# in the install tree and source it.  It will set things like
-	# CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
+	# CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.@[if RosVersion == 1]
+	# CMAKE_INSTALL_LIBDIR is set for packages that use GNUInstallDirs.@[end if]
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
 	dh_auto_configure -- \
-		-DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" \
+		-DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" \@[if RosVersion == 1]
+		-DCMAKE_INSTALL_LIBDIR="lib" \@[end if]
 		-DCMAKE_PREFIX_PATH="@(InstallationPrefix)" \
 		$(BUILD_TESTING_ARG)
 


### PR DESCRIPTION
This resolves #642

Newer debhelper versions will set CMAKE_INSTALL_LIBDIR=lib/<arch>. This will cause packages that use GNUInstallDirs to install to this location instead of lib and can confuse ROS tools.
