### PR TITLE
Replace pkg_resources.parse_version with packaging.version.parse

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools
-          python -m pip install PyYAML argparse empy rosdep vcstools catkin-pkg python-dateutil
+          python -m pip install PyYAML argparse empy rosdep vcstools catkin-pkg python-dateutil packaging
           python -m pip install nose coverage pep8
       - name: Run tests
         run: |

--- a/bloom/commands/git/import_upstream.py
+++ b/bloom/commands/git/import_upstream.py
@@ -39,7 +39,7 @@ import sys
 import tarfile
 import tempfile
 
-from packaging.version import parse
+from packaging.version import parse as parse_version
 
 try:
     from urlparse import urlparse
@@ -87,7 +87,7 @@ def version_check(version):
     info(fmt("The latest upstream tag in the release repository is '@!{0}@|'."
          .format(last_tag.replace('@', '@@'))))
     # Ensure the new version is greater than the last tag
-    if parse(version) < parse(last_tag_version):
+    if parse_version(version) < parse_version(last_tag_version):
         warning("""\
 Version discrepancy:
 The upstream version '{0}' isn't newer than upstream version '{1}'.

--- a/bloom/commands/git/import_upstream.py
+++ b/bloom/commands/git/import_upstream.py
@@ -39,7 +39,7 @@ import sys
 import tarfile
 import tempfile
 
-from pkg_resources import parse_version
+from packaging import version
 
 try:
     from urlparse import urlparse
@@ -87,7 +87,7 @@ def version_check(version):
     info(fmt("The latest upstream tag in the release repository is '@!{0}@|'."
          .format(last_tag.replace('@', '@@'))))
     # Ensure the new version is greater than the last tag
-    if parse_version(version) < parse_version(last_tag_version):
+    if version.parse(version) < version.parse(last_tag_version):
         warning("""\
 Version discrepancy:
 The upstream version '{0}' isn't newer than upstream version '{1}'.

--- a/bloom/commands/git/import_upstream.py
+++ b/bloom/commands/git/import_upstream.py
@@ -39,7 +39,7 @@ import sys
 import tarfile
 import tempfile
 
-from packaging import version
+from packaging.version import parse
 
 try:
     from urlparse import urlparse
@@ -87,7 +87,7 @@ def version_check(version):
     info(fmt("The latest upstream tag in the release repository is '@!{0}@|'."
          .format(last_tag.replace('@', '@@'))))
     # Ensure the new version is greater than the last tag
-    if version.parse(version) < version.parse(last_tag_version):
+    if parse(version) < parse(last_tag_version):
         warning("""\
 Version discrepancy:
 The upstream version '{0}' isn't newer than upstream version '{1}'.

--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -49,7 +49,7 @@ import traceback
 import webbrowser
 import yaml
 
-from pkg_resources import parse_version
+from packaging import version
 
 # python2/3 compatibility
 try:

--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -49,8 +49,6 @@ import traceback
 import webbrowser
 import yaml
 
-from packaging import version
-
 # python2/3 compatibility
 try:
     from urllib.error import HTTPError, URLError

--- a/bloom/commands/update.py
+++ b/bloom/commands/update.py
@@ -51,7 +51,7 @@ from bloom.logging import warning
 from bloom.util import add_global_arguments
 from bloom.util import handle_global_arguments
 
-from pkg_resources import parse_version
+from packaging import version
 from threading import Lock
 
 _updater_running = False
@@ -115,7 +115,7 @@ def fetch_update(user_bloom):
     newest_version = pypi_result['info']['version']
     current_version = bloom.__version__
     if newest_version and bloom.__version__ != 'unset':
-        if parse_version(bloom.__version__) < parse_version(newest_version):
+        if version.parse(bloom.__version__) < version.parse(newest_version):
             version_dict = {
                 'current': str(current_version),
                 'newest': str(newest_version)

--- a/bloom/commands/update.py
+++ b/bloom/commands/update.py
@@ -51,7 +51,7 @@ from bloom.logging import warning
 from bloom.util import add_global_arguments
 from bloom.util import handle_global_arguments
 
-from packaging import version
+from packaging.version import parse as parse_version
 from threading import Lock
 
 _updater_running = False
@@ -115,7 +115,7 @@ def fetch_update(user_bloom):
     newest_version = pypi_result['info']['version']
     current_version = bloom.__version__
     if newest_version and bloom.__version__ != 'unset':
-        if version.parse(bloom.__version__) < version.parse(newest_version):
+        if parse_version(bloom.__version__) < parse_version(newest_version):
             version_dict = {
                 'current': str(current_version),
                 'newest': str(newest_version)

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -49,7 +49,7 @@ try:
 except ImportError:
     from ConfigParser import SafeConfigParser
 from dateutil import tz
-from pkg_resources import parse_version
+from packaging import version
 
 from bloom.generators import BloomGenerator
 from bloom.generators import GeneratorError
@@ -449,7 +449,7 @@ def generate_substitutions_from_package(
         bad_changelog = True
     # Make sure that the current version is the latest in the changelog
     for changelog in changelogs:
-        if parse_version(package.version) < parse_version(changelog[0]):
+        if version.parse(package.version) < version.parse(changelog[0]):
             error("")
             error("There is at least one changelog entry, '{0}', which has a "
                   "newer version than the version of package '{1}' being released, '{2}'."

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -49,7 +49,7 @@ try:
 except ImportError:
     from ConfigParser import SafeConfigParser
 from dateutil import tz
-from packaging import version
+from packaging.version import parse as parse_version
 
 from bloom.generators import BloomGenerator
 from bloom.generators import GeneratorError
@@ -449,7 +449,7 @@ def generate_substitutions_from_package(
         bad_changelog = True
     # Make sure that the current version is the latest in the changelog
     for changelog in changelogs:
-        if version.parse(package.version) < version.parse(changelog[0]):
+        if parse_version(package.version) < parse_version(changelog[0]):
             error("")
             error("There is at least one changelog entry, '{0}', which has a "
                   "newer version than the version of package '{1}' being released, '{2}'."

--- a/bloom/generators/release.py
+++ b/bloom/generators/release.py
@@ -53,8 +53,8 @@ from bloom.commands.git.patch.trim_cmd import trim
 
 try:
     import catkin_pkg
-    from pkg_resources import parse_version
-    if parse_version(catkin_pkg.__version__) < parse_version('0.3.8'):
+    from packaging import version
+    if version.parse(catkin_pkg.__version__) < version.parse('0.3.8'):
         warning("This version of bloom requires catkin_pkg version >= '0.3.8',"
                 " the used version of catkin_pkg is '{0}'".format(catkin_pkg.__version__))
     from catkin_pkg import metapackage

--- a/bloom/generators/release.py
+++ b/bloom/generators/release.py
@@ -53,8 +53,8 @@ from bloom.commands.git.patch.trim_cmd import trim
 
 try:
     import catkin_pkg
-    from packaging import version
-    if version.parse(catkin_pkg.__version__) < version.parse('0.3.8'):
+    from packaging.version import parse as parse_version
+    if parse_version(catkin_pkg.__version__) < parse_version('0.3.8'):
         warning("This version of bloom requires catkin_pkg version >= '0.3.8',"
                 " the used version of catkin_pkg is '{0}'".format(catkin_pkg.__version__))
     from catkin_pkg import metapackage

--- a/bloom/git.py
+++ b/bloom/git.py
@@ -43,7 +43,7 @@ import tempfile
 from subprocess import PIPE
 from subprocess import CalledProcessError
 
-from pkg_resources import parse_version
+from packaging import version
 
 from bloom.logging import debug
 from bloom.logging import error
@@ -686,7 +686,7 @@ def get_last_tag_by_version(directory=None):
     versions = []
     for line in output.splitlines():
         tags.append(line.strip())
-        versions.append(parse_version(line.strip()))
+        versions.append(version.parse(line.strip()))
     return tags[versions.index(max(versions))] if versions else ''
 
 

--- a/bloom/git.py
+++ b/bloom/git.py
@@ -44,8 +44,6 @@ import tempfile
 from subprocess import PIPE
 from subprocess import CalledProcessError
 
-from packaging import version
-
 from bloom.logging import debug
 from bloom.logging import error
 from bloom.logging import fmt
@@ -687,7 +685,7 @@ def get_last_tag_by_version(directory=None):
     versions = []
     for line in output.splitlines():
         tags.append(line.strip())
-        ver = re.match("[0-9]+.[0-9]+.[0-9]+", line)
+        ver = re.match(r"[0-9]+\.[0-9]+\.[0-9]+", line)
         if ver:
             versions.append(ver)
     return tags[versions.index(max(versions))] if versions else ''

--- a/bloom/git.py
+++ b/bloom/git.py
@@ -36,6 +36,7 @@ from __future__ import print_function
 
 import os
 import functools
+import re
 import shutil
 import subprocess
 import tempfile
@@ -686,7 +687,9 @@ def get_last_tag_by_version(directory=None):
     versions = []
     for line in output.splitlines():
         tags.append(line.strip())
-        versions.append(version.parse(line.lstrip('upstream/').strip()))
+        ver = re.match("[0-9]+.[0-9]+.[0-9]+", line)
+        if ver:
+            versions.append(ver)
     return tags[versions.index(max(versions))] if versions else ''
 
 

--- a/bloom/git.py
+++ b/bloom/git.py
@@ -686,7 +686,7 @@ def get_last_tag_by_version(directory=None):
     versions = []
     for line in output.splitlines():
         tags.append(line.strip())
-        versions.append(version.parse(line.strip()))
+        versions.append(version.parse(line.lstrip('upstream/').strip()))
     return tags[versions.index(max(versions))] if versions else ''
 
 

--- a/bloom/logging.py
+++ b/bloom/logging.py
@@ -39,11 +39,6 @@ import atexit
 import datetime
 import os
 from platform import mac_ver
-try:
-    from pkg_resources import parse_version
-except OSError:
-    os.chdir(os.path.expanduser('~'))
-    from pkg_resources import parse_version
 import re
 import string
 import sys
@@ -60,7 +55,7 @@ _drop_first_log_prefix = False
 
 _emoji_check_mark = "✅  "
 _emoji_cross_mark = "❌  "
-_is_mac_lion_or_greater = parse_version(mac_ver()[0]) >= parse_version('10.7.0')
+_is_mac = (mac_ver()[0] is not '')
 
 
 def ansi(key):
@@ -127,17 +122,17 @@ def disable_ANSI_colors():
         _ansi[key] = ''
 
 
-def is_mac_lion_or_greater():
-    global _is_mac_lion_or_greater
-    return _is_mac_lion_or_greater
+def _is_mac():
+    global _is_mac
+    return _is_mac
 
 
 def get_success_prefix():
-    return _emoji_check_mark if _is_mac_lion_or_greater else "@{gf}<== @|"
+    return _emoji_check_mark if _is_mac else "@{gf}<== @|"
 
 
 def get_error_prefix():
-    return _emoji_cross_mark if _is_mac_lion_or_greater else "@{rf}@!<== @|"
+    return _emoji_cross_mark if _is_mac else "@{rf}@!<== @|"
 
 
 # Default to ansi colors on

--- a/bloom/logging.py
+++ b/bloom/logging.py
@@ -55,7 +55,7 @@ _drop_first_log_prefix = False
 
 _emoji_check_mark = "✅  "
 _emoji_cross_mark = "❌  "
-_is_mac = (mac_ver()[0] is not '')
+_is_mac = (mac_ver()[0] != '')
 
 
 def ansi(key):

--- a/bloom/rosdistro_api.py
+++ b/bloom/rosdistro_api.py
@@ -38,7 +38,7 @@ import os
 import sys
 import traceback
 
-from packaging import version
+from packaging.version import parse as parse_version
 
 # python2/3 compatibility
 try:
@@ -58,7 +58,7 @@ from bloom.logging import info
 
 try:
     import rosdistro
-    if version.parse(rosdistro.__version__) < version.parse('0.7.0'):
+    if parse_version(rosdistro.__version__) < parse_version('0.7.0'):
         error("rosdistro version 0.7.0 or greater is required, found '{0}' from '{1}'."
               .format(rosdistro.__version__, os.path.dirname(rosdistro.__file__)),
               exit=True)

--- a/bloom/rosdistro_api.py
+++ b/bloom/rosdistro_api.py
@@ -38,7 +38,7 @@ import os
 import sys
 import traceback
 
-from pkg_resources import parse_version
+from packaging import version
 
 # python2/3 compatibility
 try:
@@ -58,7 +58,7 @@ from bloom.logging import info
 
 try:
     import rosdistro
-    if parse_version(rosdistro.__version__) < parse_version('0.7.0'):
+    if version.parse(rosdistro.__version__) < version.parse('0.7.0'):
         error("rosdistro version 0.7.0 or greater is required, found '{0}' from '{1}'."
               .format(rosdistro.__version__, os.path.dirname(rosdistro.__file__)),
               exit=True)

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ install_requires = [
     'catkin_pkg >= 0.4.3',
     'setuptools',
     'empy',
+    'packaging',
     'python-dateutil',
     'PyYAML',
     'rosdep >= 0.15.0',


### PR DESCRIPTION
Resolves: #678.

Switch to packaging since use of pkg_resources is discouraged. Related: https://github.com/pypa/setuptools/issues/2497

Also:
* Uses regex to do version matching, because packaging's version parsing is a lot more strict about version numbers.
* Also, removes a check for whether a mac is Mountain Lion or greater and just changes it to a check for whether it is a mac. 