### PR TITLE
Add weekly scheduled run to make sure that CI stays green.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,8 @@ on:
     branches: ['master']
   pull_request:
     branches: ['*']
+  schedule:
+    - cron: '40 7 * * 0'
 
 jobs:
     build:


### PR DESCRIPTION
In order to keep track of regressions due to drift / bitrot versus regressions introduced by new PRs.

Answering the question of why 7:40 UTC on Sundays which was raised by @ijnek:

#### Why 7?

The clock for scheduled actions in GitHub Actions uses UTC so 07:40 UTC is 11:40 / 00:40 US Pacific which means.

#### Why 40?

Kind of no reason. GitHub Actions lacks the cron syntax extension for picking a single random value within the field (something Jenkins does with its `H` value) in order to spread scheduled build load out across the hour. 0 and 30 are the most commonly used times so I just shifted slightly from that.

#### Why Sunday?

It's the first night of the workweek which means that we can show up Monday morning and see whether the previous week brought any new issues to CI. In terms of vague "workweek" notions the objective of this build is to catch the "last" regressions of the previous week's changes rather than the "first" regressions of the coming week.

Of course, for people in UTC+ timezones this job starts in the middle of their Monday so this is a US-biased notion.