### PR TITLE
Add debian dependency to stdeb.cfg for new packaging dependency.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,8 +1,8 @@
 [DEFAULT]
 ; release with a high debinc to avoid conflict with upstream debian of the same release version
 Debian-Version: 100
-Depends: python-yaml, python-empy, python-argparse, python-rosdep (>= 0.15.0), python-rosdistro (>= 0.8.0), python-vcstools (>= 0.1.22), python-setuptools, python-catkin-pkg (>= 0.4.3)
-Depends3: python3-yaml, python3-empy, python3-rosdep (>= 0.15.0), python3-rosdistro (>= 0.8.0), python3-vcstools (>= 0.1.22), python3-setuptools, python3-catkin-pkg (>= 0.4.3)
+Depends: python-yaml, python-empy, python-argparse, python-packaging, python-rosdep (>= 0.15.0), python-rosdistro (>= 0.8.0), python-vcstools (>= 0.1.22), python-setuptools, python-catkin-pkg (>= 0.4.3)
+Depends3: python3-yaml, python3-empy, python3-packaging, python3-rosdep (>= 0.15.0), python3-rosdistro (>= 0.8.0), python3-vcstools (>= 0.1.22), python3-setuptools, python3-catkin-pkg (>= 0.4.3)
 Conflicts: python3-bloom
 Conflicts3: python-bloom
 Copyright-File: LICENSE.txt


### PR DESCRIPTION
This was introduced in #693 and I realized that it needed the stdeb dependency while I was on a walk but forgot to add that before re-reviewing and merging that PR.

This package is available for Python 2 in [Buster](https://packages.debian.org/buster/python3-packaging) and [Bionic](https://packages.ubuntu.com/bionic/python-packaging).

As well as for Python 3 in [Buster](https://packages.debian.org/buster/python3-packaging) and [Bionic](https://packages.ubuntu.com/bionic/python3-packaging) and later distributions.