### PR TITLE
Use extras_require.test and pytest for test dependencies.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,9 +28,7 @@ jobs:
           python-version: ${{matrix.python}}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools
-          python -m pip install PyYAML argparse empy rosdep vcstools catkin-pkg python-dateutil packaging
-          python -m pip install nose coverage pep8
+          python -m pip install -U -e .[test] pytest-cov
       - name: Run tests
         run: |
-          BLOOM_VERBOSE=1 python setup.py nosetests -s --tests test
+          BLOOM_VERBOSE=1 python -m pytest test --cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,10 +6,5 @@ all_files  = 1
 [upload_sphinx]
 upload-dir = doc/build/html
 
-# [nosetests]
-# where=test
-# with-coverage=0
-# cover-package=nose
-# debug=nose.loader
-# pdb=0
-# pdb-failures=0
+[tool:pytest]
+junit_suite_naem = bloom

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     },
     include_package_data=True,
     install_requires=install_requires,
-    exras_require={
+    extras_require={
         'test': [
             'pep8',
             'pytest',

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,11 @@ setup(
     },
     include_package_data=True,
     install_requires=install_requires,
+    exras_require={
+        'test': [
+            'pep8',
+            'pytest',
+        ]},
     author='Tully Foote, William Woodall',
     author_email='tfoote@openrobotics.org, william@openrobotics.org',
     maintainer='William Woodall',


### PR DESCRIPTION
This is based on the other packages have already had the same treatment.

We've gotten most packages onto pytest off of nose. I spotted that Bloom wasn't among them when I was reviewing the CI failures on master.

In order to reduce the number of places that dependencies are repeated I also set this package up to use extras_require.test to specify test dependencies.