### PR TITLE
Add bookworm as a python3 target

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -7,7 +7,7 @@ Conflicts: python3-bloom
 Conflicts3: python-bloom
 Copyright-File: LICENSE.txt
 Suite: bionic buster
-Suite3: bionic focal jammy buster bullseye
+Suite3: bionic focal jammy buster bullseye bookworm
 Python2-Depends-Name: python
 Dh-python3-params: --no-guessing-deps
 X-Python3-Version: >= 3.4


### PR DESCRIPTION
Moving support forward onto debian bookworm

This will need a backfill release or flood to fill out the repository. 