### PR TITLE
Introduce notion of "experimental" build types.

### DIFF
--- a/bloom/generators/README.md
+++ b/bloom/generators/README.md
@@ -12,4 +12,14 @@ Bloom now supports different build types by inspecting the `build_type` tag in p
 Templates for a build type are stored in subdirectories of the platform's templates directory named for the build type.
 As an example the templates for the `ament_cmake` build type for debian packages is stored in [bloom/generators/debian/templates/ament_cmake](debian/templates/ament_cmake).
 
-To add support for a new build type create a new templates subdirectory for it in your target platform's `templates` directory, and add any necessary supporting code to the generator for build type specific substitutions.For examples search for "Build-type specific substitutions" in [bloom/generators/debian/generator.py](debian/generator.py).
+### Experimental build types
+
+Certain new build types may be designated as experimental and are subject to changes in behavior.
+When relying on an experimental build type review changelogs closely when updating bloom.
+
+## Adding support for new build types
+
+To add support for a new build type create a new templates subdirectory for it in your target platform's `templates` directory, and add any necessary supporting code to the generator for build type specific substitutions.
+For examples search for "Build-type specific substitutions" in [bloom/generators/debian/generator.py](debian/generator.py).
+
+New build types should be introduced first as "experimental" by adding them to the `EXPERIMENTAL_BUILD_TYPES` list constant in each supported generator.

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -166,8 +166,9 @@ def place_template_files(path, build_type, gbp=False):
         warning("Build type {0} is marked as EXPERIMENTAL.".format(build_type))
         warning("Review bloom changelogs carefully as these build types may " +
                 "contain be unstable or make breaking changes.")
-        if not maybe_continue('y', 'Continue anyways?'):
-            sys.exit("Aborting due to experimental build type.")
+        if 'BLOOM_ALLOW_EXPERIMENTAL_BUILD_TYPES' not in os.environ:
+            if not maybe_continue('y', 'Continue anyways?'):
+                sys.exit("Aborting due to experimental build type.")
     info(fmt("@!@{bf}==>@| Placing templates files in the 'debian' folder."))
     debian_path = os.path.join(path, 'debian')
     # Create/Clean the debian folder

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -123,6 +123,7 @@ except NameError:
 enable_drop_first_log_prefix(True)
 
 TEMPLATE_EXTENSION = '.em'
+EXPERIMENTAL_BUILD_TYPES = []
 
 
 def __place_template_folder(group, src, dst, gbp=False):
@@ -161,6 +162,10 @@ def __place_template_folder(group, src, dst, gbp=False):
 
 
 def place_template_files(path, build_type, gbp=False):
+    if build_type in EXPERIMENTAL_BUILD_TYPES:
+        warning("Build type {0} is marked as EXPERIMENTAL.".format(build_type))
+        warning("Review bloom changelogs carefully as these build types may " +
+                "contain be unstable or make breaking changes.")
     info(fmt("@!@{bf}==>@| Placing templates files in the 'debian' folder."))
     debian_path = os.path.join(path, 'debian')
     # Create/Clean the debian folder

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -166,6 +166,8 @@ def place_template_files(path, build_type, gbp=False):
         warning("Build type {0} is marked as EXPERIMENTAL.".format(build_type))
         warning("Review bloom changelogs carefully as these build types may " +
                 "contain be unstable or make breaking changes.")
+        if not maybe_continue('y', 'Continue anyways?'):
+            sys.exit("Aborting due to experimental build type.")
     info(fmt("@!@{bf}==>@| Placing templates files in the 'debian' folder."))
     debian_path = os.path.join(path, 'debian')
     # Create/Clean the debian folder

--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -141,8 +141,9 @@ def place_template_files(path, build_type, gbp=False):
         warning("Build type {0} is marked as EXPERIMENTAL.".format(build_type))
         warning("Review bloom changelogs carefully as these build types may " +
                 "contain be unstable or make breaking changes.")
-        if not maybe_continue('y', 'Continue anyways?'):
-            sys.exit("Aborting due to experimental build type.")
+        if 'BLOOM_ALLOW_EXPERIMENTAL_BUILD_TYPES' not in os.environ:
+            if not maybe_continue('y', 'Continue anyways?'):
+                sys.exit("Aborting due to experimental build type.")
     info(fmt("@!@{bf}==>@| Placing templates files in the 'rpm' folder."))
     rpm_path = os.path.join(path, 'rpm')
     # Create/Clean the rpm folder

--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -141,6 +141,8 @@ def place_template_files(path, build_type, gbp=False):
         warning("Build type {0} is marked as EXPERIMENTAL.".format(build_type))
         warning("Review bloom changelogs carefully as these build types may " +
                 "contain be unstable or make breaking changes.")
+        if not maybe_continue('y', 'Continue anyways?'):
+            sys.exit("Aborting due to experimental build type.")
     info(fmt("@!@{bf}==>@| Placing templates files in the 'rpm' folder."))
     rpm_path = os.path.join(path, 'rpm')
     # Create/Clean the rpm folder

--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -104,6 +104,7 @@ except ImportError:
 enable_drop_first_log_prefix(True)
 
 TEMPLATE_EXTENSION = '.em'
+EXPERIMENTAL_BUILD_TYPES = []
 
 
 def __place_template_folder(group, src, dst, gbp=False):
@@ -136,6 +137,10 @@ def __place_template_folder(group, src, dst, gbp=False):
 
 
 def place_template_files(path, build_type, gbp=False):
+    if build_type in EXPERIMENTAL_BUILD_TYPES:
+        warning("Build type {0} is marked as EXPERIMENTAL.".format(build_type))
+        warning("Review bloom changelogs carefully as these build types may " +
+                "contain be unstable or make breaking changes.")
     info(fmt("@!@{bf}==>@| Placing templates files in the 'rpm' folder."))
     rpm_path = os.path.join(path, 'rpm')
     # Create/Clean the rpm folder


### PR DESCRIPTION
When per build type templates were introduced for ROS 2 support, little thought was given to how the number of build types might expand in the future. I think that there's good fodder for a rethink of the build type handling in general, but in the meantime I would like to introduce this concept and a small warning to signify the possibility that these new build types are outside the focus of the core infrastructure team.

The initial criteria for a build type being "experimental" is that it's novel.
Criteria for graduating from an experimental build type to normal one is not currently settled.