### PR TITLE
Debian generator support for architecture_independent flag

### DIFF
--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -342,6 +342,11 @@ def generate_substitutions_from_package(
     data['format'] = 'native' if native else 'quilt'
     # Package name
     data['Package'] = sanitize_package_name(package.name)
+    # Architecture
+    exported_tags = [e.tagname for e in package.exports]
+    architecture_independent = 'metapackage' in exported_tags or \
+        'architecture_independent' in exported_tags
+    data['Architecture'] = 'all' if architecture_independent else 'any'
     # Installation prefix
     data['InstallationPrefix'] = installation_prefix
     # Resolve dependencies

--- a/bloom/generators/debian/templates/ament_cmake/control.em
+++ b/bloom/generators/debian/templates/ament_cmake/control.em
@@ -7,7 +7,7 @@ Homepage: @(Homepage)
 Standards-Version: 3.9.2
 
 Package: @(Package)
-Architecture: any
+Architecture: @(Architecture)
 Depends: ${shlibs:Depends}, ${misc:Depends}, @(', '.join(Depends))
 @[if Conflicts]Conflicts: @(', '.join(Conflicts))@\n@[end if]@
 @[if Replaces]Replaces: @(', '.join(Replaces))@\n@[end if]@

--- a/bloom/generators/debian/templates/ament_python/control.em
+++ b/bloom/generators/debian/templates/ament_python/control.em
@@ -7,7 +7,7 @@ Homepage: @(Homepage)
 Standards-Version: 3.9.2
 
 Package: @(Package)
-Architecture: any
+Architecture: @(Architecture)
 Depends: ${python3:Depends}, ${misc:Depends}, @(', '.join(Depends))
 @[if Conflicts]Conflicts: @(', '.join(Conflicts))@\n@[end if]@
 @[if Replaces]Replaces: @(', '.join(Replaces))@\n@[end if]@

--- a/bloom/generators/debian/templates/catkin/control.em
+++ b/bloom/generators/debian/templates/catkin/control.em
@@ -7,7 +7,7 @@ Homepage: @(Homepage)
 Standards-Version: 3.9.2
 
 Package: @(Package)
-Architecture: any
+Architecture: @(Architecture)
 Depends: ${shlibs:Depends}, ${misc:Depends}, @(', '.join(Depends))
 @[if Conflicts]Conflicts: @(', '.join(Conflicts))@\n@[end if]@
 @[if Replaces]Replaces: @(', '.join(Replaces))@\n@[end if]@

--- a/bloom/generators/debian/templates/cmake/control.em
+++ b/bloom/generators/debian/templates/cmake/control.em
@@ -7,7 +7,7 @@ Homepage: @(Homepage)
 Standards-Version: 3.9.2
 
 Package: @(Package)
-Architecture: any
+Architecture: @(Architecture)
 Depends: ${shlibs:Depends}, ${misc:Depends}, @(', '.join(Depends))
 @[if Conflicts]Conflicts: @(', '.join(Conflicts))@\n@[end if]@
 @[if Replaces]Replaces: @(', '.join(Replaces))@\n@[end if]@


### PR DESCRIPTION
The `Architecture` field is set to `all` if a package has `metapackage` or `architecture_independent` in the exports in its `package.xml`.

This is analogous to the support in the RPM generator (https://github.com/ros-infrastructure/bloom/pull/270).