### PR TITLE
skip stripping issues

### DIFF
--- a/bloom/generators/debian/templates/ament_cmake/rules.em
+++ b/bloom/generators/debian/templates/ament_cmake/rules.em
@@ -65,3 +65,6 @@ override_dh_auto_install:
 	# CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
 	dh_auto_install
+
+override_dh_strip:
+	dh_strip || true

--- a/bloom/generators/debian/templates/cmake/rules.em
+++ b/bloom/generators/debian/templates/cmake/rules.em
@@ -67,3 +67,6 @@ override_dh_auto_install:
 	# CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
 	dh_auto_install
+
+override_dh_strip:
+	dh_strip || true


### PR DESCRIPTION
The rules for Debian packages force stripping of the installed binaries. This does not always work, for example, stripping errors may occur for officially distributed binaries from a third party. This ignores stripping errors such that dbgsym packages can still be created even when some files cannot be stripped.