### PR TITLE
enable parallel builds for debian

### DIFF
--- a/bloom/generators/debian/templates/ament_cmake/rules.em
+++ b/bloom/generators/debian/templates/ament_cmake/rules.em
@@ -24,7 +24,7 @@ endif
 DEB_HOST_GNU_TYPE ?= $(shell dpkg-architecture -qDEB_HOST_GNU_TYPE)
 
 %:
-	dh $@@ -v --buildsystem=cmake --builddirectory=.obj-$(DEB_HOST_GNU_TYPE)
+	dh $@@ -v --buildsystem=cmake --parallel --builddirectory=.obj-$(DEB_HOST_GNU_TYPE)
 
 override_dh_auto_configure:
 	# In case we're installing to a non-standard location, look for a setup.sh

--- a/bloom/generators/debian/templates/cmake/rules.em
+++ b/bloom/generators/debian/templates/cmake/rules.em
@@ -27,7 +27,7 @@ export DEB_HOST_MULTIARCH := $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 DEB_HOST_GNU_TYPE ?= $(shell dpkg-architecture -qDEB_HOST_GNU_TYPE)
 
 %:
-	dh $@@ -v --buildsystem=cmake --builddirectory=.obj-$(DEB_HOST_GNU_TYPE)
+	dh $@@ -v --buildsystem=cmake --parallel --builddirectory=.obj-$(DEB_HOST_GNU_TYPE)
 
 override_dh_auto_configure:
 	# In case we're installing to a non-standard location, look for a setup.sh


### PR DESCRIPTION
By default, depending on the CMake generator, build jobs do not run in parallel. Fix this by passing the `--parallel` flag which then allows to run parallel jobs by passing options to `DEB_BUILD_OPTIONS`, e.g. `DEB_BUILD_OPTIONS="parallel=8" fakeroot debian/rules binary`.