### PR TITLE
Update deb platforms and drop python2 packaging.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,13 +1,10 @@
 [DEFAULT]
 ; release with a high debinc to avoid conflict with upstream debian of the same release version
 Debian-Version: 100
-Depends: python-yaml, python-empy, python-argparse, python-packaging, python-rosdep (>= 0.15.0), python-rosdistro (>= 0.8.0), python-vcstools (>= 0.1.22), python-setuptools, python-catkin-pkg (>= 0.4.3)
 Depends3: python3-yaml, python3-empy, python3-packaging, python3-rosdep (>= 0.15.0), python3-rosdistro (>= 0.8.0), python3-vcstools (>= 0.1.22), python3-setuptools, python3-catkin-pkg (>= 0.4.3)
 Conflicts: python3-bloom
 Conflicts3: python-bloom
 Copyright-File: LICENSE.txt
-Suite: bionic buster
-Suite3: bionic focal jammy buster bullseye
-Python2-Depends-Name: python
+Suite3: focal jammy noble bookworm trixie
 Dh-python3-params: --no-guessing-deps
-X-Python3-Version: >= 3.4
+X-Python3-Version: >= 3.6

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -2,7 +2,6 @@
 ; release with a high debinc to avoid conflict with upstream debian of the same release version
 Debian-Version: 100
 Depends3: python3-yaml, python3-empy, python3-packaging, python3-rosdep (>= 0.15.0), python3-rosdistro (>= 0.8.0), python3-vcstools (>= 0.1.22), python3-setuptools, python3-catkin-pkg (>= 0.4.3)
-Conflicts: python3-bloom
 Conflicts3: python-bloom
 Copyright-File: LICENSE.txt
 Suite3: focal jammy noble bookworm trixie


### PR DESCRIPTION
Following in the wake of catkin_pkg, we're dropping python2 support now that it's no longer the default on any active distribution.

Dropped:
* Ubuntu Bionic (18.04 LTS)
* Debian Buster (oldoldstable)
* Debian Bullseye (oldstable)

Added:
* Ubuntu Noble (24.04 LTS pre-release)
* Debian Trixie (testing)

Retained:
* Ubuntu Focal (20.04 LTS)
* Ubuntu Jammy (22.04 LTS)

I have also raised the minimum python3 version to 3.6 as we are only testing back to 3.6 and RHEL 8 has the oldest python distribution (3.6) of any supported platform.

#723 updates the CI platforms targeted by bloom.
Ref: https://github.com/ros2/ros2/issues/1511