### PR TITLE
Modernize CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,38 +1,20 @@
-name: bloom-ci
+---
+name: Run tests
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     branches: ['master']
   pull_request:
-    branches: ['*']
-  schedule:
-    - cron: '40 7 * * 0'
 
 jobs:
-    build:
-      strategy:
-        matrix:
-          os: [ubuntu-latest, macos-latest]
-          python: [3.7, 3.8, 3.9]
-          include:
-          - os: ubuntu-18.04
-            python: 2.7
-          - os: ubuntu-18.04
-            python: 3.6
-      name: bloom tests
-      runs-on: ${{matrix.os}}
-
-      steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{matrix.python}}
-        uses: actions/setup-python@v1
-        with:
-          python-version: ${{matrix.python}}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools
-          python -m pip install PyYAML argparse empy rosdep vcstools catkin-pkg python-dateutil packaging
-          python -m pip install nose coverage pep8
-      - name: Run tests
-        run: |
-          BLOOM_VERBOSE=1 python setup.py nosetests -s --tests test
+  pytest:
+    uses: ros-infrastructure/ci/.github/workflows/pytest.yaml@main
+    with:
+      matrix-filter: >-
+        del(.matrix.os[] | select(contains("windows"))) | del(.matrix.python[] |
+        select(contains("3.10") or contains("3.11") or contains("3.12")))
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: yamllint -f github .

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,10 +6,5 @@ all_files  = 1
 [upload_sphinx]
 upload-dir = doc/build/html
 
-# [nosetests]
-# where=test
-# with-coverage=0
-# cover-package=nose
-# debug=nose.loader
-# pdb=0
-# pdb-failures=0
+[tool:pytest]
+junit_suite_name = bloom

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 install_requires = [
     'catkin_pkg >= 0.4.3',
     'setuptools',
-    'empy',
+    'empy < 4',
     'packaging',
     'python-dateutil',
     'PyYAML',

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,11 @@ setup(
     },
     include_package_data=True,
     install_requires=install_requires,
+    extras_require={
+        'test': [
+            'pep8',
+            'pytest',
+        ]},
     author='Tully Foote, William Woodall',
     author_email='tfoote@openrobotics.org, william@openrobotics.org',
     maintainer='William Woodall',


### PR DESCRIPTION
* Switch to extras_require.test
* Pin to empy < 4
* Switch to unified ros-infrastructure CI

Note that Bloom tests are broken with Python 3.10+, so I'm excluding that from CI in favor of a followup fix. This PR is intended simply to get the train moving again.