### PR TITLE
Create a fake rosdistro index for better test isolation

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -6,6 +6,12 @@ if 'PATH' in os.environ:
     scripts = os.path.abspath(scripts)
     os.environ['PATH'] = scripts + ':' + os.environ['PATH']
 
+os.environ['ROSDISTRO_INDEX_URL'] = 'file://' + os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    'fake_rosdistro',
+    'index-v4.yaml',
+)
+
 user_email = 'test@example.com'
 user_name = 'Test User'
 

--- a/test/fake_rosdistro/index-v4.yaml
+++ b/test/fake_rosdistro/index-v4.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+distributions:
+  melodic:
+    distribution: [melodic/distribution.yaml]
+    distribution_status: end-of-life
+    distribution_type: ros1
+    python_version: 2
+type: index
+version: 4

--- a/test/fake_rosdistro/melodic/distribution.yaml
+++ b/test/fake_rosdistro/melodic/distribution.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+release_platforms:
+  debian:
+    - buster
+  ubuntu:
+    - bionic
+repositories: []
+type: distribution
+version: 2


### PR DESCRIPTION
The tests currently require the rosdistro index to be reachable.