### PR TITLE
Switch from SafeConfigParser to ConfigParser

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,9 +10,7 @@ jobs:
   pytest:
     uses: ros-infrastructure/ci/.github/workflows/pytest.yaml@main
     with:
-      matrix-filter: >-
-        del(.matrix.os[] | select(contains("windows"))) | del(.matrix.python[] |
-        select(contains("3.10") or contains("3.11") or contains("3.12")))
+      matrix-filter: del(.matrix.os[] | select(contains("windows")))
   yamllint:
     runs-on: ubuntu-latest
     steps:

--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -45,9 +45,9 @@ import traceback
 
 # Python 2/3 support.
 try:
-    from configparser import SafeConfigParser
+    from configparser import ConfigParser
 except ImportError:
-    from ConfigParser import SafeConfigParser
+    from ConfigParser import SafeConfigParser as ConfigParser
 from dateutil import tz
 from packaging.version import parse as parse_version
 
@@ -397,7 +397,7 @@ def generate_substitutions_from_package(
         setup_cfg_path = os.path.join(package_path, 'setup.cfg')
         data['pass_install_scripts'] = True
         if os.path.isfile(setup_cfg_path):
-            setup_cfg = SafeConfigParser()
+            setup_cfg = ConfigParser()
             setup_cfg.read([setup_cfg_path])
             if (
                     setup_cfg.has_option('install', 'install-scripts') or

--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -44,11 +44,6 @@ import sys
 import traceback
 import textwrap
 
-# Python 2/3 support.
-try:
-    from configparser import SafeConfigParser
-except ImportError:
-    from ConfigParser import SafeConfigParser
 from dateutil import tz
 from distutils.version import LooseVersion
 from time import strptime


### PR DESCRIPTION
The configparser.SafeConfigParser class was renamed to ConfigParser in Python 3.2. In Python 3.10, it was finally removed.

The import was copy/pasted from the debian generator to the RPM generator, but isn't actually used there and could be removed.