### PR TITLE
Use raw strings for regular expressions

### DIFF
--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -603,7 +603,7 @@ def get_package_from_branch(branch):
 def debianize_string(value):
     markup_remover = re.compile(r'<.*?>')
     value = markup_remover.sub('', value)
-    value = re.sub('\s+', ' ', value)
+    value = re.sub(r'\s+', ' ', value)
     value = value.strip()
     return value
 

--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -442,7 +442,7 @@ def get_package_from_branch(branch):
 def rpmify_string(value):
     markup_remover = re.compile(r'<.*?>')
     value = markup_remover.sub('', value)
-    value = re.sub('\s+', ' ', value)
+    value = re.sub(r'\s+', ' ', value)
     value = '\n'.join([v.strip() for v in
                       textwrap.TextWrapper(width=80, break_long_words=False, replace_whitespace=False).wrap(value)])
     return value

--- a/docs/bump_version.py
+++ b/docs/bump_version.py
@@ -13,10 +13,10 @@ if __name__ == '__main__':
     args = parser.parse_args()
     with open(args.file, 'r') as f:
         lines = f.read()
-    version_line_regex = re.compile(".*version='\d*[.]\d*[.]\d*'.*")
+    version_line_regex = re.compile(r".*version='\d*[.]\d*[.]\d*'.*")
     version_line = version_line_regex.findall(lines)
     version_line = version_line[0]
-    version_regex = re.compile('\d*[.]\d*[.]\d*')
+    version_regex = re.compile(r'\d*[.]\d*[.]\d*')
     version_str = version_regex.findall(version_line)[0]
     version_str = version_str.split('.')
     version_str[-1] = str(int(version_str[-1]) + 1)

--- a/test/system_tests/test_catkin_release.py
+++ b/test/system_tests/test_catkin_release.py
@@ -375,7 +375,7 @@ def test_multi_package_repository(directory=None):
                     package_xml = f.read()
                     assert package_xml.count('<name>' + pkg + '</name>'), \
                         "incorrect package.xml for " + str(pkg)
-                    format_version = int(re.search('format="(\d+)"',
+                    format_version = int(re.search(r'format="(\d+)"',
                                                    package_xml).group(1))
                 # Is there a copyright file for this pkg?
                 with open('debian/copyright', 'r') as f:

--- a/test/utils/package_version.py
+++ b/test/utils/package_version.py
@@ -48,7 +48,7 @@ def bump_version(version, bump='patch'):
         parts reset to 0
     """
     # split the version number
-    match = re.match('^(\d+)\.(\d+)\.(\d+)$', version)
+    match = re.match(r'^(\d+)\.(\d+)\.(\d+)$', version)
     if match is None:
         raise ValueError(
             'Invalid version string, must be int.int.int: "%s"' % version
@@ -75,8 +75,8 @@ def _replace_version(package_str, new_version):
     """
     # try to replace contens
     new_package_str, number_of_subs = re.subn(
-        '<version([^<>]*)>[^<>]*</version>',
-        '<version\g<1>>%s</version>' % new_version, package_str
+        r'<version([^<>]*)>[^<>]*</version>',
+        r'<version\g<1>>%s</version>' % new_version, package_str
     )
     if number_of_subs != 1:
         raise RuntimeError(


### PR DESCRIPTION
Should avoid `SyntaxWarning: invalid escape sequence`