### PR TITLE
Fix template file inclusion in Python package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-recursive-include bloom/generators/debian/templates *
-recursive-include bloom/generators/rpm/templates *

--- a/setup.py
+++ b/setup.py
@@ -27,14 +27,13 @@ setup(
     packages=find_packages(exclude=['test', 'test.*']),
     package_data={
         'bloom.generators.debian': [
-            'bloom/generators/debian/templates/*',
-            'bloom/generators/debian/templates/source/*'
+            'templates/*/*',
+            'templates/*/source/*',
         ],
         'bloom.generators.rpm': [
-            'bloom/generators/rpm/templates/*'
-        ]
+            'templates/*/*.em',
+        ],
     },
-    include_package_data=True,
     install_requires=install_requires,
     extras_require={
         'test': [


### PR DESCRIPTION
The setuptools documentation states that `package_data` is used for finer-grained control over the inclusion of package data as an alternative to `include_package_data`/`MANIFEST.in`. After correcting the glob patterns in `package_data`, the latter mechanisms are no longer needed.

Docs: https://setuptools.pypa.io/en/latest/userguide/datafiles.html#configuration-options

Should alleviate warnings like this:
```
/usr/lib/python3.12/site-packages/setuptools/command/build_py.py:201: _Warning: Package 'bloom.generators.rpm.templates.cmake' is absent from the `packages` configuration.
!!

        ********************************************************************************
        ############################
        # Package would be ignored #
        ############################
        Python recognizes 'bloom.generators.rpm.templates.cmake' as an importable package[^1],
        but it is absent from setuptools' `packages` configuration.

        This leads to an ambiguous overall configuration. If you want to distribute this
        package, please make sure that 'bloom.generators.rpm.templates.cmake' is explicitly added
        to the `packages` configuration field.

        Alternatively, you can also rely on setuptools' discovery methods
        (for example by using `find_namespace_packages(...)`/`find_namespace:`
        instead of `find_packages(...)`/`find:`).

        You can read more about "package discovery" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

        If you don't want 'bloom.generators.rpm.templates.cmake' to be distributed and are
        already explicitly excluding 'bloom.generators.rpm.templates.cmake' via
        `find_namespace_packages(...)/find_namespace` or `find_packages(...)/find`,
        you can try to use `exclude_package_data`, or `include-package-data=False` in
        combination with a more fine grained `package-data` configuration.

        You can read more about "package data files" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


        [^1]: For Python, any directory (with suitable naming) can be imported,
              even if it does not contain any `.py` files.
              On the other hand, currently there is no concept of package data
              directory, all directories are treated like packages.
        ********************************************************************************

!!
```