### PR TITLE
Add dh_shlibdeps entry for libraries installed by ament_vendor

### DIFF
--- a/bloom/generators/debian/templates/ament_cmake/rules.em
+++ b/bloom/generators/debian/templates/ament_cmake/rules.em
@@ -57,7 +57,7 @@ override_dh_shlibdeps:
 	# in the install tree and source it.  It will set things like
 	# CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
-	dh_shlibdeps -l$(CURDIR)/debian/@(Package)/@(InstallationPrefix)/lib/
+	dh_shlibdeps -l$(CURDIR)/debian/@(Package)/@(InstallationPrefix)/lib/:$(CURDIR)/debian/@(Package)/@(InstallationPrefix)/opt/@(Name)/lib/
 
 override_dh_auto_install:
 	# In case we're installing to a non-standard location, look for a setup.sh


### PR DESCRIPTION
It seems that `dh_shlibdeps` needs to know about each location where shared object libraries are installed so that it knows which libraries are provided by a package. This is particularly important information in the context of multiple inter-linked libraries within a single package.

The `ament_vendor` macro provided by `ament_cmake_vendor_package` installs to the `opt/{package_name}` sub-tree, so we should search for dynamic libraries there as well.

https://man7.org/linux/man-pages/man1/dh_shlibdeps.1.html