### PR TITLE
Update Debian Compatibility Level

### DIFF
--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -462,8 +462,9 @@ def generate_substitutions_from_package(
         if not maybe_continue('n', 'Continue anyways'):
             sys.exit("User quit.")
     data['changelogs'] = changelogs
-    # Use debhelper version 7 for oneric, otherwise 9
-    data['debhelper_version'] = 7 if os_version in ['oneiric'] else 9
+    # Use compat version 10 as recommended by debian
+    # https://www.debian.org/doc/manuals/maint-guide/dother.en.html#compat
+    data['debhelper_version'] = 10
     # Summarize dependencies
     summarize_dependency_mapping(data, depends, build_depends, resolved_deps)
     # Copyright


### PR DESCRIPTION
This commit updates the Debian compatibility level to adhere to the recommendations outlined in the Debian documentation: https://www.debian.org/doc/manuals/maint-guide/dother.en.html#compat

This change resolves the following warning generated by debhelper:
```text
dh: warning: Compatibility levels before 10 are deprecated (level 9 in use)
```

Additionally, the conditional value for Ubuntu Oneiric has been removed, as the latest version no longer requires it.