### PR TITLE
fix ROS installation prefix for RPM generator

### DIFF
--- a/bloom/generators/rosrpm.py
+++ b/bloom/generators/rosrpm.py
@@ -163,7 +163,8 @@ def get_subs(pkg, os_name, os_version, ros_distro):
         pkg,
         os_name,
         os_version,
-        ros_distro
+        ros_distro,
+        RosRpmGenerator.default_install_prefix + ros_distro,
     )
     subs['Package'] = rosify_package_name(subs['Package'], ros_distro)
     return subs


### PR DESCRIPTION
The default 'installation_prefix' is '/usr'. This is wrong for 'rosrpm' and has to be prefixed correctly with the default ROS installation.

With a "standard" bloom pipeline for RPM with something like:
```sh
# [...] setup ROS repo
dnf install python3-bloom
git clone https://github.com/AprilRobotics/apriltag.git
cd apriltag
bloom-generate rosrpm --ros-distro humble
dnf builddep -y rpm/template.spec
rpmbuild -bb --build-in-place rpm/template.spec
```
I am getting spec files with `@(InstallationPrefix)` set to `/usr`:
```spec
%build
# In case we're installing to a non-standard location, look for a setup.sh
# in the install tree and source it.  It will set things like
# CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
if [ -f "/usr/setup.sh" ]; then . "/usr/setup.sh"; fi
mkdir -p .obj-%{_target_platform} && cd .obj-%{_target_platform}
%cmake3 \
    -UINCLUDE_INSTALL_DIR \
    -ULIB_INSTALL_DIR \
    -USYSCONF_INSTALL_DIR \
    -USHARE_INSTALL_PREFIX \
    -ULIB_SUFFIX \
    -DCMAKE_INSTALL_PREFIX="/usr" \
    -DAMENT_PREFIX_PATH="/usr" \
    -DCMAKE_PREFIX_PATH="/usr" \
    -DSETUPTOOLS_DEB_LAYOUT=OFF \
%if !0%{?with_tests}
    -DBUILD_TESTING=OFF \
%endif
    ..
```

Hence, the `rpmbuild` will fail.

With this PR (`pip3 install -U git+https://github.com/christianrauch/bloom.git@fix_rosrpm`):
```
/usr/local/bin/bloom-generate rosrpm --ros-distro humble
```
generates a spec file with `@(InstallationPrefix)` correctly set to `/opt/ros/humble`:
```spec
%build
# In case we're installing to a non-standard location, look for a setup.sh
# in the install tree and source it.  It will set things like
# CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
if [ -f "/opt/ros/humble/setup.sh" ]; then . "/opt/ros/humble/setup.sh"; fi
mkdir -p .obj-%{_target_platform} && cd .obj-%{_target_platform}
%cmake3 \
    -UINCLUDE_INSTALL_DIR \
    -ULIB_INSTALL_DIR \
    -USYSCONF_INSTALL_DIR \
    -USHARE_INSTALL_PREFIX \
    -ULIB_SUFFIX \
    -DCMAKE_INSTALL_PREFIX="/opt/ros/humble" \
    -DAMENT_PREFIX_PATH="/opt/ros/humble" \
    -DCMAKE_PREFIX_PATH="/opt/ros/humble" \
    -DSETUPTOOLS_DEB_LAYOUT=OFF \
%if !0%{?with_tests}
    -DBUILD_TESTING=OFF \
%endif
    ..
```

Also, see this equivalent fix for `rosdebian` from 10y ago: https://github.com/ros-infrastructure/bloom/pull/288 :-)