### PR TITLE
use CMake rpm macros and unset in-source builds

### DIFF
--- a/bloom/generators/rpm/templates/ament_cmake/template.spec.em
+++ b/bloom/generators/rpm/templates/ament_cmake/template.spec.em
@@ -5,6 +5,8 @@
 %global __provides_exclude_from ^@(InstallationPrefix)/.*$
 %global __requires_exclude_from ^@(InstallationPrefix)/.*$
 
+%global __cmake_in_source_build 1
+
 Name:           @(Package)
 Version:        @(Version)
 Release:        @(RPMInc)%{?dist}%{?release_suffix}

--- a/bloom/generators/rpm/templates/cmake/template.spec.em
+++ b/bloom/generators/rpm/templates/cmake/template.spec.em
@@ -5,6 +5,8 @@
 %global __provides_exclude_from ^@(InstallationPrefix)/.*$
 %global __requires_exclude_from ^@(InstallationPrefix)/.*$
 
+%global __cmake_in_source_build 1
+
 Name:           @(Package)
 Version:        @(Version)
 Release:        @(RPMInc)%{?dist}%{?release_suffix}


### PR DESCRIPTION
The RPM CMake macros under `/usr/lib/rpm/macros.d/macros.cmake` are defined differently for RHEL / AlmaLinux 8 and 9. Specifically, under AlmaLinux 8 in-source builds are enabled via `%__cmake_in_source_build 1` and AlmaLinux 9 turns of stripping via `-DCMAKE_INSTALL_DO_STRIP:BOOL=OFF`.

The effect is that the evaluation of the macros generates different spec files. This can be verified via:
```sh
# AlmaLinux 8
docker run --rm almalinux:8 bash -c "dnf -y install cmake && rpm --eval '%cmake' && rpm --eval '%cmake_build'"
# AlmaLinux 9
docker run --rm almalinux:9 bash -c "dnf -y install cmake && rpm --eval '%cmake' && rpm --eval '%cmake_build'"
```

On AlmaLinux 8 this evaluates to:
```spec
%if 0 
  %set_build_flags 
%else 
  CFLAGS="${CFLAGS:--O2 -g}" ; export CFLAGS ; 
  CXXFLAGS="${CXXFLAGS:--O2 -g}" ; export CXXFLAGS ; 
  FFLAGS="${FFLAGS:--O2 -g}" ; export FFLAGS ; 
  FCFLAGS="${FCFLAGS:--O2 -g}" ; export FCFLAGS ; 
   
%endif 
  /usr/bin/cmake \
         \
         \
        -DCMAKE_C_FLAGS_RELEASE:STRING="-DNDEBUG" \
        -DCMAKE_CXX_FLAGS_RELEASE:STRING="-DNDEBUG" \
        -DCMAKE_Fortran_FLAGS_RELEASE:STRING="-DNDEBUG" \
        -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
        -DCMAKE_INSTALL_PREFIX:PATH=/usr \
        -DINCLUDE_INSTALL_DIR:PATH=/usr/include \
        -DLIB_INSTALL_DIR:PATH=/usr/lib64 \
        -DSYSCONF_INSTALL_DIR:PATH=/etc \
        -DSHARE_INSTALL_PREFIX:PATH=/usr/share \
%if "lib64" == "lib64" 
        -DLIB_SUFFIX=64 \
%endif 
        -DBUILD_SHARED_LIBS:BOOL=ON

  /usr/bin/cmake --build "." -j8 --verbose
```

On AlmaLinux 9 this evaluates to:
```spec
%if 01 
  
  CFLAGS="${CFLAGS:--O2 -g}" ; export CFLAGS ; 
  CXXFLAGS="${CXXFLAGS:--O2 -g}" ; export CXXFLAGS ; 
  FFLAGS="${FFLAGS:--O2 -g }" ; export FFLAGS ; 
  FCFLAGS="${FCFLAGS:--O2 -g }" ; export FCFLAGS ; 
  LDFLAGS="${LDFLAGS:-}" ; export LDFLAGS 
%else 
  CFLAGS="${CFLAGS:--O2 -g}" ; export CFLAGS ; 
  CXXFLAGS="${CXXFLAGS:--O2 -g}" ; export CXXFLAGS ; 
  FFLAGS="${FFLAGS:--O2 -g}" ; export FFLAGS ; 
  FCFLAGS="${FCFLAGS:--O2 -g}" ; export FCFLAGS ; 
   
%endif 
  /usr/bin/cmake \
        -S "%{_vpath_srcdir}" \
        -B "%{_vpath_builddir}" \
        -DCMAKE_C_FLAGS_RELEASE:STRING="-DNDEBUG" \
        -DCMAKE_CXX_FLAGS_RELEASE:STRING="-DNDEBUG" \
        -DCMAKE_Fortran_FLAGS_RELEASE:STRING="-DNDEBUG" \
        -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
        -DCMAKE_INSTALL_DO_STRIP:BOOL=OFF \
        -DCMAKE_INSTALL_PREFIX:PATH=/usr \
        -DINCLUDE_INSTALL_DIR:PATH=/usr/include \
        -DLIB_INSTALL_DIR:PATH=/usr/lib64 \
        -DSYSCONF_INSTALL_DIR:PATH=/etc \
        -DSHARE_INSTALL_PREFIX:PATH=/usr/share \
%if "lib64" == "lib64" 
        -DLIB_SUFFIX=64 \
%endif 
        -DBUILD_SHARED_LIBS:BOOL=ON

  /usr/bin/cmake --build "%{_vpath_builddir}" -j8 --verbose
```

Notice the difference in the build path (`-B`, `--build`) for the configure and build procedure. On AlmaLinux 8, the build path is the source path due to `%__cmake_in_source_build 1`, on AlmaLinux 9, there is a dedicated build folder.

This PR fixes the issue by unsetting `__cmake_in_source_build` and thus reverting back to out-of-source builds for both distributions. I am also replacing the manual calls of the "make" macros with their "cmake" counterpart. See https://docs.fedoraproject.org/en-US/packaging-guidelines/CMake/#_available_macros.


