### PR TITLE
Prepare 0.13.0 release.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+0.13.0 (2025-06-29 21:30:00 -0700)
+----------------------------------
+- Add bloom templates for meson build system. `#691 <https://github.com/ros-infrastructure/bloom/issues/691>`_
+- Updates for python3. `#736 <https://github.com/ros-infrastructure/bloom/issues/736>`_
+- Fix a typo. `#735 <https://github.com/ros-infrastructure/bloom/issues/735`_
+
 0.12.0 (2024-03-29 17:20:00 -0500)
 ----------------------------------
 - Fix regression in RHEL 8 / Python3.6 support. `#700 <https://github.com/ros-infrastructure/bloom/issues/700>`_

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='bloom',
-    version='0.12.0',
+    version='0.13.0',
     packages=find_packages(exclude=['test', 'test.*']),
     package_data={
         'bloom.generators.debian': [


### PR DESCRIPTION
Principally includes meson support and some smaller python changes. I decided to proceed rather than wait for #747 but could be convinced to fold that in too.