### PR TITLE
Optimize PR branch calculation 

### DIFF
--- a/bloom/commands/release.py
+++ b/bloom/commands/release.py
@@ -744,7 +744,11 @@ Increasing version of package(s) in repository `{repository}` to `{version}`:
             _my_run("mkdir -p {base_info[repo]}".format(**locals()))
             with change_directory(base_info['repo']):
                 _my_run('git init')
-                branches = [x['name'] for x in gh.list_branches(head_org, head_repo)]
+                # Use git ls-remote to find existing branches on the fork
+                ls_remote_cmd = "git ls-remote --heads {rosdistro_fork_url}".format(**locals())
+                from bloom.util import check_output
+                branches_out = check_output(ls_remote_cmd, shell=True)
+                branches = [l.split()[1].replace('refs/heads/', '') for l in branches_out.splitlines()]
                 new_branch = 'bloom-{repository}-{count}'
                 count = 0
                 while new_branch.format(repository=repository, count=count) in branches:


### PR DESCRIPTION
This uses `git ls-remote` instead of hitting the Github APIs for getting
a list of branches on the fork repo. This is faster and avoids Github's
rate limiting.

Generated-By: Gemini 2.5 Pro