### PR TITLE
Enable dynamic RPM generator

### DIFF
--- a/bloom/config.py
+++ b/bloom/config.py
@@ -253,7 +253,7 @@ ACTION_LIST_HISTORY = [
         'git-bloom-generate -y rosrpm --prefix release/:{ros_distro}'
         ' :{ros_distro} -i :{release_inc} --os-name rhel',
         'git-bloom-generate -y rosdynrpm --prefix release/:{ros_distro}'
-        ' :{ros_distro} -i :{release_inc} --only-os-names fedora rhel',
+        ' :{ros_distro} -i :{release_inc} --require-os fedora rhel',
     ]
 ]
 

--- a/bloom/config.py
+++ b/bloom/config.py
@@ -235,6 +235,25 @@ ACTION_LIST_HISTORY = [
         ' :{ros_distro} -i :{release_inc} --os-name fedora',
         'git-bloom-generate -y rosrpm --prefix release/:{ros_distro}'
         ' :{ros_distro} -i :{release_inc} --os-name rhel',
+    ],
+    [
+        'bloom-export-upstream :{vcs_local_uri} :{vcs_type}'
+        ' --tag :{release_tag} --display-uri :{vcs_uri}'
+        ' --name :{name} --output-dir :{archive_dir_path}',
+        'git-bloom-import-upstream :{archive_path} :{patches}'
+        ' --release-version :{version} --replace',
+        'git-bloom-generate -y rosrelease :{ros_distro}'
+        ' --source upstream -i :{release_inc}',
+        'git-bloom-generate -y rosdebian --prefix release/:{ros_distro}'
+        ' :{ros_distro} -i :{release_inc} --os-name ubuntu',
+        'git-bloom-generate -y rosdebian --prefix release/:{ros_distro}'
+        ' :{ros_distro} -i :{release_inc} --os-name debian --os-not-required',
+        'git-bloom-generate -y rosrpm --prefix release/:{ros_distro}'
+        ' :{ros_distro} -i :{release_inc} --os-name fedora',
+        'git-bloom-generate -y rosrpm --prefix release/:{ros_distro}'
+        ' :{ros_distro} -i :{release_inc} --os-name rhel',
+        'git-bloom-generate -y rosdynrpm --prefix release/:{ros_distro}'
+        ' :{ros_distro} -i :{release_inc} --only-os-names fedora rhel',
     ]
 ]
 

--- a/bloom/generators/dynrpm/generator.py
+++ b/bloom/generators/dynrpm/generator.py
@@ -371,10 +371,21 @@ class DynRpmGenerator(BloomGenerator):
                  "even if not in current upstream")
         add('--install-prefix', default=None,
             help="overrides the default installation prefix (/usr)")
+        add('--only-os-names', nargs='*', required=False,
+            help="skip generation if rosdistro doesn't have any of "
+                 "these platforms listed")
 
     def handle_arguments(self, args):
         self.interactive = args.interactive
         self.rpm_inc = args.rpm_inc
+        if args.only_os_names:
+            index = rosdistro.get_index(rosdistro.get_index_url())
+            distribution_file = rosdistro.get_distribution_file(index, self.rosdistro)
+            if not set(args.only_os_names).intersection(distribution_file.release_platforms):
+                warning("No platforms defined for given OS filter in release file for the '{0}' distro."
+                        "\nNot performing dynamic RPM generation."
+                        .format(self.rosdistro))
+                sys.exit(0)
         self.install_prefix = args.install_prefix
         if args.install_prefix is None:
             self.install_prefix = self.default_install_prefix

--- a/bloom/generators/dynrpm/generator.py
+++ b/bloom/generators/dynrpm/generator.py
@@ -371,17 +371,17 @@ class DynRpmGenerator(BloomGenerator):
                  "even if not in current upstream")
         add('--install-prefix', default=None,
             help="overrides the default installation prefix (/usr)")
-        add('--only-os-names', nargs='*', required=False,
+        add('--require-os', nargs='*', required=False,
             help="skip generation if rosdistro doesn't have any of "
                  "these platforms listed")
 
     def handle_arguments(self, args):
         self.interactive = args.interactive
         self.rpm_inc = args.rpm_inc
-        if args.only_os_names:
+        if args.require_os:
             index = rosdistro.get_index(rosdistro.get_index_url())
             distribution_file = rosdistro.get_distribution_file(index, self.rosdistro)
-            if not set(args.only_os_names).intersection(distribution_file.release_platforms):
+            if not set(args.require_os).intersection(distribution_file.release_platforms):
                 warning("No platforms defined for given OS filter in release file for the '{0}' distro."
                         "\nNot performing dynamic RPM generation."
                         .format(self.rosdistro))

--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -482,6 +482,14 @@ class RpmGenerator(BloomGenerator):
             help="dependency keys which should be skipped and"
                  " discluded from the RPM dependencies")
 
+    @staticmethod
+    def _filter_dynrpm_distros(os_name, distros):
+        if os_name == 'fedora':
+            return list(filter(lambda d: not d.isdigit() or int(d) < 43, distros))
+        elif os_name == 'rhel':
+            return list(filter(lambda d: not d.isdigit() or int(d) < 10, distros))
+        return distros
+
     def handle_arguments(self, args):
         self.interactive = args.interactive
         self.rpm_inc = args.rpm_inc
@@ -497,6 +505,12 @@ class RpmGenerator(BloomGenerator):
                         .format(self.os_name, self.rosdistro))
                 sys.exit(0)
             self.distros = distribution_file.release_platforms[self.os_name]
+            self.distros = self._filter_dynrpm_distros(self.os_name, self.distros)
+            if not self.distros:
+                warning("All platforms defined for os '{0}' have migrated to the 'dynrpm' generator."
+                        "\nNot performing (legacy) RPM generation."
+                        .format(self.os_name))
+                sys.exit(0)
         self.install_prefix = args.install_prefix
         if args.install_prefix is None:
             self.install_prefix = self.default_install_prefix


### PR DESCRIPTION
The legacy RPM generator will now be disabled for RHEL < 10 and Fedora < 43. The dynamic RPM generator runs very quickly and will be enabled if Fedora or RHEL are supported in the target ROS distro.

This will result in a change to the "action list", and the first release operation for every release repository will prompt the developer to update to the new default action list. The developer can accept the default at the prompt (yes) and their action list will automatically move to the new list.