### PR TITLE
Switch dynrpm generator to use central empy logic

### DIFF
--- a/bloom/generators/dynrpm/generator.py
+++ b/bloom/generators/dynrpm/generator.py
@@ -72,6 +72,7 @@ from bloom.commands.git.patch.common import set_patch_config
 from bloom.packages import get_package_data
 
 from bloom.util import execute_command
+from bloom.util import expand_template_em
 from bloom.util import maybe_continue
 
 if sys.version_info[0:2] < (3, 10):
@@ -84,12 +85,6 @@ try:
 except ImportError as err:
     debug(traceback.format_exc())
     error("rosdistro was not detected, please install it.", exit=True)
-
-try:
-    import em
-except ImportError:
-    debug(traceback.format_exc())
-    error("empy was not detected, please install it.", exit=True)
 
 # Drop the first log prefix for this command
 enable_drop_first_log_prefix(True)
@@ -273,7 +268,7 @@ def __process_template_folder(path, subs):
         info("Expanding '{0}' -> '{1}'".format(
             os.path.relpath(item),
             os.path.relpath(template_path)))
-        result = em.expand(template, **subs)
+        result = expand_template_em(template, subs)
         # Write the result
         with io.open(template_path, 'w', encoding='utf-8') as f:
             if sys.version_info.major == 2:


### PR DESCRIPTION
The change to EmPy 4 was authored in parallel with the dynamic RPM generator, so it missed the template expansion changes for compatibility with EmPy 4.

Closes #765 
Follows #762 and #753