### PR TITLE
Duplicate branch list to avoid skipping entries

### DIFF
--- a/bloom/generators/debian/generator.py
+++ b/bloom/generators/debian/generator.py
@@ -584,7 +584,7 @@ def match_branches_with_prefix(prefix, get_branches, prune=False):
         # Prune listed branches by packages in latest upstream
         with inbranch('upstream'):
             pkg_names, version, pkgs_dict = get_package_data('upstream')
-            for branch in branches:
+            for branch in branches.copy():
                 if branch.split(prefix)[-1].strip('/') not in pkg_names:
                     branches.remove(branch)
     return branches

--- a/bloom/generators/dynrpm/generator.py
+++ b/bloom/generators/dynrpm/generator.py
@@ -305,7 +305,7 @@ def match_branches_with_prefix(prefix, get_branches, prune=False, release_inc='1
         # Prune listed branches by packages in latest upstream
         with inbranch('upstream'):
             pkg_names, version, pkgs_dict = get_package_data('upstream')
-            for branch in branches:
+            for branch in branches.copy():
                 if branch.split(prefix)[-1].strip('/') not in pkg_names:
                     branches.remove(branch)
         branches = [

--- a/bloom/generators/rpm/generator.py
+++ b/bloom/generators/rpm/generator.py
@@ -416,7 +416,7 @@ def match_branches_with_prefix(prefix, get_branches, prune=False):
         # Prune listed branches by packages in latest upstream
         with inbranch('upstream'):
             pkg_names, version, pkgs_dict = get_package_data('upstream')
-            for branch in branches:
+            for branch in branches.copy():
                 if branch.split(prefix)[-1].strip('/') not in pkg_names:
                     branches.remove(branch)
     return branches


### PR DESCRIPTION
This loop is changing the list of branches while it's iterating over it. I can't explain why this hasn't been blowing up builds for the past decade, but at least on Python 3.14, this can result in skipping entries in the list when other entries are removed.