### PR TITLE
Don't target release tags for dynrpm branches

### DIFF
--- a/bloom/generators/dynrpm/generator.py
+++ b/bloom/generators/dynrpm/generator.py
@@ -291,7 +291,7 @@ def process_template_files(path, subs):
     return __process_template_folder(rpm_dir, subs)
 
 
-def match_branches_with_prefix(prefix, get_branches, prune=False, release_inc='1'):
+def match_branches_with_prefix(prefix, get_branches, prune=False):
     debug("match_branches_with_prefix(" + str(prefix) + ", " +
           str(get_branches()) + ")")
     branches = []
@@ -310,10 +310,6 @@ def match_branches_with_prefix(prefix, get_branches, prune=False, release_inc='1
             for branch in branches.copy():
                 if branch.split(prefix)[-1].strip('/') not in pkg_names:
                     branches.remove(branch)
-        branches = [
-            branch + '/' + version + '-' + release_inc
-            for branch in branches
-        ]
     return branches
 
 
@@ -387,8 +383,7 @@ class DynRpmGenerator(BloomGenerator):
         if args.install_prefix is None:
             self.install_prefix = self.default_install_prefix
         self.prefix = args.prefix
-        self.branches = match_branches_with_prefix(
-            self.prefix, get_branches, prune=not args.match_all, release_inc=self.rpm_inc)
+        self.branches = match_branches_with_prefix(self.prefix, get_branches, prune=not args.match_all)
         if len(self.branches) == 0:
             error(
                 "No packages found, check your --prefix or --src arguments.",


### PR DESCRIPTION
I wrote this code a long time ago so it's hard to remember, but it's likely I was trying to be clever by targeting the release tags instead of the release branches for the branching source when creating dynrpm branches. In theory, this would have allowed the dynrpm generator to be run without relying on the rosrelease generator running before it, but in practice it just broke the patching system.

This commit aligns the branch matching function with the rpm and debian generators, restoring proper patch re-application and aligning the behavior with the existing generators.