### PR TITLE
Drop 'path' from Cargo dependencies during rebase

### DIFF
--- a/bloom/generators/release.py
+++ b/bloom/generators/release.py
@@ -195,7 +195,7 @@ Please checkout the release branch and then create a tag manually with:""")
 
         for spec in (
             spec for category in (
-                'dependenices',
+                'dependencies',
                 'dev-dependencies',
                 'build-dependencies',
             ) for spec in data.get('dependencies', {}).values()

--- a/bloom/generators/release.py
+++ b/bloom/generators/release.py
@@ -32,7 +32,16 @@
 
 from __future__ import print_function
 
+import os
 import traceback
+
+import tomli_w
+
+try:
+    import tomllib
+except ImportError:
+    # For python < 3.11
+    import tomli as tomllib
 
 from bloom.generators import BloomGenerator
 
@@ -126,6 +135,9 @@ each package in the upstream repository, so the source branch should be set to
         # Execute trim
         if trim_d in ['', '.']:
             return
+        ret = self._normalize_cargo_manifest(trim_d)
+        if ret:
+            return ret
         return trim(trim_d)
 
     def post_patch(self, destination):
@@ -168,3 +180,31 @@ Please checkout the release branch and then create a tag manually with:""")
                     # Check for valid CMakeLists.txt if a metapackage
                     self.metapackage_check(path, pkg)
             return name if type(name) is list else [name]
+
+    def _normalize_cargo_manifest(self, sub_dir=None):
+        if sub_dir:
+            manifest = os.path.join(sub_dir, 'Cargo.toml')
+        else:
+            manifest = 'Cargo.toml'
+        if not os.path.isfile(manifest):
+            return
+
+        print('Normalizing Cargo.toml')
+        with open(manifest, 'rb') as f:
+            data = tomllib.load(f)
+
+        for spec in (
+            spec for category in (
+                'dependenices',
+                'dev-dependencies',
+                'build-dependencies',
+            ) for spec in data.get('dependencies', {}).values()
+        ):
+            if not isinstance(spec, dict):
+                continue
+
+            if spec.pop('path', None):
+                spec.setdefault('version', '*')
+
+        with open(manifest, 'wb') as f:
+            tomli_w.dump(data, f)

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@ setup(
         'PyYAML',
         'rosdep >= 0.15.0',
         'rosdistro >= 0.8.0',
+        'tomli >= 1.0.0; python_version < "3.11"',
+        'tomli-w',
         'vcstools >= 0.1.22',
     ],
     extras_require={

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
 Upstream-Version-Suffix: +upstream
-Depends3: python3-yaml, python3-empy, python3-packaging, python3-rosdep (>= 0.15.0), python3-rosdistro (>= 0.8.0), python3-vcstools (>= 0.1.22), python3-catkin-pkg (>= 0.4.3), python3 (>= 3.10) | python3-importlib-metadata (>= 3.6), python3 (>= 3.10) | python3-importlib-resources (>= 5.0)
+Depends3: python3-yaml, python3-empy, python3-packaging, python3-rosdep (>= 0.15.0), python3-rosdistro (>= 0.8.0), python3-vcstools (>= 0.1.22), python3-catkin-pkg (>= 0.4.3), python3 (>= 3.10) | python3-importlib-metadata (>= 3.6), python3 (>= 3.10) | python3-importlib-resources (>= 5.0), python3 (>= 3.11) | python3-tomli (>= 1), python3-tomli-w
 Conflicts3: python-bloom
 Copyright-File: LICENSE.txt
 Suite3: jammy noble resolute bookworm trixie


### PR DESCRIPTION
The Bloom rebasing process involves trimming the repository contents to only include the package being released. Cargo manifests can reference other packages in the repository using a 'path' value as part of the dependency spec, which is no longer valid.

Remove all 'path' values from dependencies and add a placeholder 'version' value if one is not already present such that the manifest is still valid.

---

Eventually, we'll want this normalization process to be more involved so that we can de-workspace the cargo packages as well. This is done as part of `cargo package` and `cargo read-manifest`.

I'm not 100% certain that this is the right place to do this. Maybe it should be an implicit patch, or should be moved to `rosrelease.py`, or should maybe be conditional on detecting a package of type `cargo` or `ament_cargo`. I'm open to suggestions.