### PR TITLE
Modify paths for vendored crates and use --offline configuration

### DIFF
--- a/bloom/generators/debian/templates/cargo/rules.em
+++ b/bloom/generators/debian/templates/cargo/rules.em
@@ -33,9 +33,24 @@ override_dh_auto_configure:
 	# CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
 	dh_auto_configure
-	# Generate a pallet-patcher config so that, once we have a viable
-	# vendoring solution, we can point cargo to local deps
-	pallet-patcher --output-format=toml Cargo.toml @(InstallationPrefix)/share/cargo/registry > pallet-patcher.toml
+	# Generate a pallet-patcher config pointing cargo at the crates that are
+	# already on disk. The search paths are consulted in the order given, so
+	# crates from other ROS packages win over the ones the platform ships.
+	pallet-patcher --output-format=toml Cargo.toml \
+		@(InstallationPrefix)/share/cargo/registry \
+		/usr/share/cargo/registry > pallet-patcher.toml
+	# The sourcedeb job vendors the crates.io dependencies into debian/vendor
+	# and rejects crates from any other source, so the replacement cargo needs
+	# to build against them is always this one stanza. It covers every crate
+	# left unpatched above, which is deliberately the only way the vendored
+	# copies are reached: patching them in would turn them into path
+	# dependencies, and cargo-auditable redacts local paths from the .dep-v0
+	# section, losing them from the SBOM. Note the directory has to be
+	# absolute: cargo resolves relative paths in a file passed to '--config'
+	# against that file's grandparent directory, not the working directory.
+	if [ -d debian/vendor ]; then \
+		printf '\n[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "$(CURDIR)/debian/vendor"\n' >> pallet-patcher.toml ; \
+	fi
 
 override_dh_auto_clean:
 	dh_auto_clean

--- a/bloom/generators/debian/templates/cargo/rules.em
+++ b/bloom/generators/debian/templates/cargo/rules.em
@@ -92,7 +92,10 @@ override_dh_auto_install:
 	#   - HAS_LIB: lay down the unpacked crate source under
 	#     <prefix>/share/cargo/registry/<name>-<version>/ so downstream ROS
 	#     Rust packages can resolve this crate via pallet-patcher. Mirrors
-	#     dh-cargo cargo.pm:install() libpkg branch.
+	#     dh-cargo cargo.pm:install() libpkg branch, except that we also
+	#     carry the vendored crates: a downstream package recompiles this
+	#     crate from source, so it needs whatever this crate could not source
+	#     from the platform. pallet-patcher looks for them in 'vendor'.
 	#   - HAS_BIN: run `cargo auditable install`, which wraps cargo and
 	#     embeds a compressed JSON SBOM into each binary's .dep-v0 ELF
 	#     section. Tools that read it: cargo audit bin, trivy, grype, syft,
@@ -112,6 +115,7 @@ override_dh_auto_install:
 			\! -name '.obj-*' \! -name 'pallet-patcher.toml' \
 			-exec cp -a -t "$$TARGET" {} + ; \
 		rm -rf "$$TARGET/target" ; \
+		[ ! -d debian/vendor ] || cp -a debian/vendor "$$TARGET/vendor" ; \
 		cp debian/cargo-checksum.json "$$TARGET/.cargo-checksum.json" ; \
 		[ -z "$$SOURCE_DATE_EPOCH" ] || touch -d@@$$SOURCE_DATE_EPOCH "$$TARGET/Cargo.toml" ; \
 	fi ; \

--- a/bloom/generators/debian/templates/cargo/rules.em
+++ b/bloom/generators/debian/templates/cargo/rules.em
@@ -24,10 +24,10 @@ DEB_HOST_GNU_TYPE ?= $(shell dpkg-architecture -qDEB_HOST_GNU_TYPE)
 	dh $@@ -v --buildsystem=cargo --builddirectory=.obj-$(DEB_HOST_GNU_TYPE)
 
 override_dh_auto_configure:
-	# dh-cargo's configure step expects these two files to exist, even when
-	# we aren't vendoring dependencies. Touching an empty cargo-checksum.json
-	# and Cargo.lock is the canonical workaround (see Debian wiki: Rust Packaging).
-	touch debian/cargo-checksum.json Cargo.lock
+	# dh-cargo's configure step copies this file into place, so it has to
+	# exist even when we aren't vendoring dependencies (see Debian wiki: Rust
+	# Packaging). It does not need a Cargo.lock: that same step removes one.
+	touch debian/cargo-checksum.json
 	# In case we're installing to a non-standard location, look for a setup.sh
 	# in the install tree and source it.  It will set things like
 	# CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
@@ -51,6 +51,12 @@ override_dh_auto_configure:
 	if [ -d debian/vendor ]; then \
 		printf '\n[source.crates-io]\nreplace-with = "vendored-sources"\n\n[source.vendored-sources]\ndirectory = "$(CURDIR)/debian/vendor"\n' >> pallet-patcher.toml ; \
 	fi
+	# Every crate has to be on disk by now, so refuse to reach the network.
+	# Set as config rather than passing --offline so that it also covers the
+	# cargo invocations we do not spell out ourselves. This stops cargo
+	# fetching, it does NOT stop build scripts or proc macros from opening
+	# their own connections; that needs an isolated build container.
+	printf '\n[net]\noffline = true\n' >> pallet-patcher.toml
 
 override_dh_auto_clean:
 	dh_auto_clean


### PR DESCRIPTION
Changes:

* if the crate being build includes debian/vendor (meaning included vendored crates), we also include a section in the configuration to replace crates.io with local vendored source.
* printf '\n[net]\noffline = true\n' >> pallet-patcher.toml -> Configure cargo to build offline. It won't stop build.rs scripts and other macros, but this keeps ros_buildfarm current behavior.
* Moves vendored crates from `debian/vendor` to `vendor` (cp -a debian/vendor "$$TARGET/vendor") when these are installed. They can't be kept in `debian` because that folder is used for packaging metadata.